### PR TITLE
Add ways to generate diffs and compare two instances of the same model

### DIFF
--- a/napalm_yang/yang_base.py
+++ b/napalm_yang/yang_base.py
@@ -80,6 +80,9 @@ class BaseBinding(object):
             if issubclass(attr.__class__, BaseBinding) or issubclass(attr.__class__, YangType):
                 yield a, attr
 
+    def __eq__(self, other):
+        return self.diff(other) == {}
+
     def model_to_dict(self):
         """Returns a dict with information about the model itself."""
         result = {}
@@ -109,6 +112,16 @@ class BaseBinding(object):
 
     def data_to_text(self, indentation=""):
         return data_to_text(self.__class__.__name__, self.data_to_dict())
+
+    def diff(self, other):
+        result = {}
+
+        for attr_name, attr in self.items():
+            res = attr.diff(getattr(other, attr_name))
+            if res:
+                result[attr_name] = res
+
+        return result
 
 
 class YangType(object):
@@ -168,6 +181,12 @@ class YangType(object):
             self._value = value
         else:
             raise ValueError("Wrong value for {}: {}".format(value, self.__class__.__name__))
+
+    def diff(self, other):
+        if self.value != other.value:
+            return {"mine": self.value, "other": other.value}
+        else:
+            return {}
 
     def model_to_dict(self):
         """Returns a dict with information about the model itself."""

--- a/napalm_yang/yang_builtin_types.py
+++ b/napalm_yang/yang_builtin_types.py
@@ -411,6 +411,25 @@ class List(BaseBinding):
 
         return res
 
+    def diff(self, other):
+        res = {"both": {}, "mine": {}, "other": {}}
+
+        for k, v in self.items():
+            if k in other:
+                r = v.diff(other[k])
+                if r:
+                    res["both"][k] = r
+            else:
+                res["mine"][k] = v.data_to_dict()
+
+        for k in set(set(other.keys()) - set(self.keys())):
+            res["other"][k] = other[k].data_to_dict()
+
+        if res["both"] or res["mine"] or res["other"]:
+            return res
+        else:
+            return {}
+
     def __contains__(self, key):
         return key in self._value
 

--- a/test/unit/test_compare_model_instances.py
+++ b/test/unit/test_compare_model_instances.py
@@ -1,0 +1,319 @@
+"""Tests comparing two models."""
+#  import pytest
+
+from napalm_yang import oc_if
+
+import json
+
+diff_1 = """{
+    "interfaces": {
+        "interface": {
+            "both": {
+                "et1": {
+                    "state": {
+                        "mtu": {
+                            "other": 9000,
+                            "mine": 1500
+                        }
+                    },
+                    "config": {
+                        "mtu": {
+                            "other": 9000,
+                            "mine": 1500
+                        }
+                    }
+                }
+            },
+            "other": {
+                "et3": {
+                    "state": {
+                        "_meta": {
+                            "config": false
+                        },
+                        "type_": {
+                            "_meta": {
+                                "mandatory": true,
+                                "nested": false,
+                                "config": false,
+                                "type": "Identityref"
+                            },
+                            "value": null
+                        },
+                        "admin_status": {
+                            "_meta": {
+                                "nested": false,
+                                "mandatory": true,
+                                "enum": null,
+                                "config": false,
+                                "type": "Enumeration"
+                            },
+                            "value": null,
+                            "enum_value": null
+                        },
+                        "oper_status": {
+                            "_meta": {
+                                "nested": false,
+                                "mandatory": true,
+                                "enum": null,
+                                "config": false,
+                                "type": "Enumeration"
+                            },
+                            "value": null,
+                            "enum_value": null
+                        },
+                        "mtu": {
+                            "_meta": {
+                                "mandatory": false,
+                                "nested": false,
+                                "config": false,
+                                "type": "Uint16"
+                            },
+                            "value": 9000
+                        }
+                    },
+                    "config": {
+                        "_meta": {
+                            "config": true
+                        },
+                        "type_": {
+                            "_meta": {
+                                "mandatory": true,
+                                "nested": false,
+                                "config": false,
+                                "type": "Identityref"
+                            },
+                            "value": null
+                        },
+                        "description": {
+                            "_meta": {
+                                "mandatory": false,
+                                "nested": false,
+                                "config": false,
+                                "type": "String"
+                            },
+                            "value": "Interface exists only in iright"
+                        },
+                        "mtu": {
+                            "_meta": {
+                                "mandatory": false,
+                                "nested": false,
+                                "config": false,
+                                "type": "Uint16"
+                            },
+                            "value": 9000
+                        }
+                    },
+                    "_meta": {
+                        "config": true,
+                        "key": "name"
+                    },
+                    "subinterfaces": {
+                        "_meta": {
+                            "config": true
+                        },
+                        "subinterface": {
+                            "list": {},
+                            "_meta": {
+                                "config": true,
+                                "key": "index"
+                            }
+                        }
+                    }
+                }
+            },
+            "mine": {
+                "et2": {
+                    "state": {
+                        "_meta": {
+                            "config": false
+                        },
+                        "type_": {
+                            "_meta": {
+                                "mandatory": true,
+                                "nested": false,
+                                "config": false,
+                                "type": "Identityref"
+                            },
+                            "value": null
+                        },
+                        "admin_status": {
+                            "_meta": {
+                                "nested": false,
+                                "mandatory": true,
+                                "enum": null,
+                                "config": false,
+                                "type": "Enumeration"
+                            },
+                            "value": null,
+                            "enum_value": null
+                        },
+                        "oper_status": {
+                            "_meta": {
+                                "nested": false,
+                                "mandatory": true,
+                                "enum": null,
+                                "config": false,
+                                "type": "Enumeration"
+                            },
+                            "value": null,
+                            "enum_value": null
+                        },
+                        "mtu": {
+                            "_meta": {
+                                "mandatory": false,
+                                "nested": false,
+                                "config": false,
+                                "type": "Uint16"
+                            },
+                            "value": 1500
+                        }
+                    },
+                    "config": {
+                        "_meta": {
+                            "config": true
+                        },
+                        "type_": {
+                            "_meta": {
+                                "mandatory": true,
+                                "nested": false,
+                                "config": false,
+                                "type": "Identityref"
+                            },
+                            "value": null
+                        },
+                        "description": {
+                            "_meta": {
+                                "mandatory": false,
+                                "nested": false,
+                                "config": false,
+                                "type": "String"
+                            },
+                            "value": "Interface exists only in ileft"
+                        },
+                        "mtu": {
+                            "_meta": {
+                                "mandatory": false,
+                                "nested": false,
+                                "config": false,
+                                "type": "Uint16"
+                            },
+                            "value": 1500
+                        }
+                    },
+                    "_meta": {
+                        "config": true,
+                        "key": "name"
+                    },
+                    "subinterfaces": {
+                        "_meta": {
+                            "config": true
+                        },
+                        "subinterface": {
+                            "list": {},
+                            "_meta": {
+                                "config": true,
+                                "key": "index"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+class TestYangBuiltinTypes:
+    """Wrap tests and fixture."""
+
+    def test_diff_same_object(self):
+        """Test the same object has no diff when compared to itself."""
+        ileft = oc_if.Interfaces()
+
+        ileft.interfaces.interface.get_element("et1")
+        ileft.interfaces.interface["et1"].config.description("asdasda")
+        ileft.interfaces.interface["et1"].config.mtu(1500)
+        ileft.interfaces.interface["et1"].state.mtu(1500)
+
+        assert not ileft.diff(ileft)
+
+    def test_diff_equal_objects(self):
+        """Test that two interfaces are equal have no diff."""
+        ileft = oc_if.Interfaces()
+        iright = oc_if.Interfaces()
+
+        ileft.interfaces.interface.get_element("et1")
+        ileft.interfaces.interface["et1"].config.description("asdasda")
+        ileft.interfaces.interface["et1"].config.mtu(1500)
+        ileft.interfaces.interface["et1"].state.mtu(1500)
+        iright.interfaces.interface.get_element("et1")
+        iright.interfaces.interface["et1"].config.description("asdasda")
+        iright.interfaces.interface["et1"].config.mtu(1500)
+        iright.interfaces.interface["et1"].state.mtu(1500)
+
+        assert not ileft.diff(iright)
+
+    def test_diff_diferent_objects(self):
+        """Test diff on different objects."""
+        ileft = oc_if.Interfaces()
+        iright = oc_if.Interfaces()
+
+        ileft.interfaces.interface.new_element("et1")
+        ileft.interfaces.interface["et1"].config.description("Interface exists in both")
+        ileft.interfaces.interface["et1"].config.mtu(1500)
+        ileft.interfaces.interface["et1"].state.mtu(1500)
+        ileft.interfaces.interface.new_element("et2")
+        ileft.interfaces.interface["et2"].config.description("Interface exists only in ileft")
+        ileft.interfaces.interface["et2"].config.mtu(1500)
+        ileft.interfaces.interface["et2"].state.mtu(1500)
+
+        iright.interfaces.interface.new_element("et1")
+        iright.interfaces.interface["et1"].config.description("Interface exists in both")
+        iright.interfaces.interface["et1"].config.mtu(9000)
+        iright.interfaces.interface["et1"].state.mtu(9000)
+        iright.interfaces.interface.new_element("et3")
+        iright.interfaces.interface["et3"].config.description("Interface exists only in iright")
+        iright.interfaces.interface["et3"].config.mtu(9000)
+        iright.interfaces.interface["et3"].state.mtu(9000)
+
+        assert ileft.diff(iright) == json.loads(diff_1)
+
+    def test_compare_same_object(self):
+        ileft = oc_if.Interfaces()
+        iright = oc_if.Interfaces()
+
+        ileft.interfaces.interface.get_element("et1")
+        ileft.interfaces.interface["et1"].config.description("asdasda")
+        ileft.interfaces.interface["et1"].config.mtu(1500)
+        ileft.interfaces.interface["et1"].state.mtu(1500)
+        iright.interfaces.interface.get_element("et1")
+        iright.interfaces.interface["et1"].config.description("asdasda")
+        iright.interfaces.interface["et1"].config.mtu(1500)
+        iright.interfaces.interface["et1"].state.mtu(1500)
+
+        assert ileft == iright
+
+    def test_compare_different_objects(self):
+        ileft = oc_if.Interfaces()
+        iright = oc_if.Interfaces()
+
+        ileft.interfaces.interface.new_element("et1")
+        ileft.interfaces.interface["et1"].config.description("Interface exists in both")
+        ileft.interfaces.interface["et1"].config.mtu(1500)
+        ileft.interfaces.interface["et1"].state.mtu(1500)
+        ileft.interfaces.interface.new_element("et2")
+        ileft.interfaces.interface["et2"].config.description("Interface exists only in ileft")
+        ileft.interfaces.interface["et2"].config.mtu(1500)
+        ileft.interfaces.interface["et2"].state.mtu(1500)
+
+        iright.interfaces.interface.new_element("et1")
+        iright.interfaces.interface["et1"].config.description("Interface exists in both")
+        iright.interfaces.interface["et1"].config.mtu(9000)
+        iright.interfaces.interface["et1"].state.mtu(9000)
+        iright.interfaces.interface.new_element("et3")
+        iright.interfaces.interface["et3"].config.description("Interface exists only in iright")
+        iright.interfaces.interface["et3"].config.mtu(9000)
+        iright.interfaces.interface["et3"].state.mtu(9000)
+
+        assert ileft != iright


### PR DESCRIPTION
Basically adds the `__eq__` magic method to compare two bindings of the same type and it also implements a `diff` function to tell how to get from a given model to another.

Implements #9 