### PR TITLE
Change _to_dict_list function to use iteritems()

### DIFF
--- a/napalm_yang/base.py
+++ b/napalm_yang/base.py
@@ -339,7 +339,7 @@ def _to_dict_container(element, filter):
 def _to_dict_list(element, filter):
     result = {}
 
-    for k, v in element.items():
+    for k, v in element.iteritems():
         r = _to_dict(v, filter)
         if r not in [None, {}]:
             result[k] = r


### PR DESCRIPTION
When using `to_dict` I receive the following:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/luke/git/napalm-logs/napalm_logs/device.py", line 242, in start
    oc_obj = self._emit(**kwargs)
  File "/home/luke/git/napalm-logs/napalm_logs/device.py", line 207, in _emit
    return oc_obj.to_dict(filter=True)
  File "/home/luke/venvs/napalm-logs/local/lib/python2.7/site-packages/napalm_yang/base.py", line 181, in to_dict
    r = _to_dict(v, filter)
  File "/home/luke/venvs/napalm-logs/local/lib/python2.7/site-packages/napalm_yang/base.py", line 319, in _to_dict
    result = _to_dict_container(element, filter)
  File "/home/luke/venvs/napalm-logs/local/lib/python2.7/site-packages/napalm_yang/base.py", line 333, in _to_dict_container
    r = _to_dict(v, filter)
  File "/home/luke/venvs/napalm-logs/local/lib/python2.7/site-packages/napalm_yang/base.py", line 319, in _to_dict
    result = _to_dict_container(element, filter)
  File "/home/luke/venvs/napalm-logs/local/lib/python2.7/site-packages/napalm_yang/base.py", line 333, in _to_dict_container
    r = _to_dict(v, filter)
  File "/home/luke/venvs/napalm-logs/local/lib/python2.7/site-packages/napalm_yang/base.py", line 321, in _to_dict
    result = _to_dict_list(element, filter)
  File "/home/luke/venvs/napalm-logs/local/lib/python2.7/site-packages/napalm_yang/base.py", line 342, in _to_dict_list
    for k, v in element.items():
AttributeError: 'YANGBaseClass' object has no attribute 'items'
```