### PR TITLE
Fix issue with ios layer3 not being properly identified

### DIFF
--- a/napalm_yang/mappings/ios/parsers/config/openconfig-if-ip/ipv4.yaml
+++ b/napalm_yang/mappings/ios/parsers/config/openconfig-if-ip/ipv4.yaml
@@ -9,7 +9,7 @@ ipv4:
         enabled:
             _process: # TODO look at this one, I think this is different depending on IOS version
                 mode: is_absent
-                regexp: "(?P<value>^\\W*switchport$)"
+                regexp: "(?P<value>^\\s*switchport mode.*$)"
                 from: "{{ bookmarks['parent'] }}"
         mtu:
             _process: not_implemented


### PR DESCRIPTION
Layer2 ports did not have an explicit 'switchport' line. The previous regex was incorrectly identifying layer2 ports as layer3.

Here is an example (from Cisco 881 that has both Layer2 and Layer3 ports)

# Layer2 port
```
interface FastEthernet3
 switchport access vlan 1
 switchport trunk encapsulation dot1q
 switchport trunk native vlan 1
 switchport trunk allowed vlan 1-4094
 switchport mode access
 switchport voice vlan none
 switchport priority extend none
 switchport priority default 0
 mtu 1500
 no ip address
 load-interval 300
 carrier-delay 2
 no shutdown
 tx-ring-limit 0
 tx-queue-limit 0
 dot1q tunneling ethertype 0x8100
 no mab
 snmp trap mac-notification added
 snmp trap mac-notification removed
 snmp trap link-status
 no onep application openflow exclusive
  cdp log mismatch duplex
 cdp tlv app
 arp arpa
 arp timeout 14400
 hold-queue 75 in
 hold-queue 40 out
 ip igmp snooping tcn flood
 no bgp-policy accounting input
 no bgp-policy accounting output
 no bgp-policy accounting input source
 no bgp-policy accounting output source
 no bgp-policy source ip-prec-map
 no bgp-policy source ip-qos-map
 no bgp-policy destination ip-prec-map
 no bgp-policy destination ip-qos-map
```

Layer3 port:
```
interface FastEthernet4
 description *** LAN connection (don't change) ***
 mtu 1500
 ip address 10.220.88.20 255.255.255.0
 ip redirects
 ip unreachables
 ip proxy-arp
 ip mtu 1500
 ip pim dr-priority 1
 ip pim query-interval 30
 ip pim join-prune-interval 60
 ip mfib forwarding input
 ip mfib forwarding output
 ip mfib cef input
 ip mfib cef output
 ip cef accounting non-recursive internal
 ip load-sharing per-destination
 ip route-cache cef
 ip route-cache
 ip split-horizon
 ip igmp last-member-query-interval 1000
 ip igmp last-member-query-count 2
 ip igmp query-max-response-time 10
 ip igmp v3-query-max-response-time 10
 ip igmp version 2
 ip igmp query-interval 60
 ip igmp tcn query count 2
 ip igmp tcn query interval 10
 load-interval 300
 carrier-delay 2
 no shutdown
 tx-ring-limit 64
 tx-queue-limit 64
 duplex auto
 speed auto
 ipv6 nd reachable-time 0
 ipv6 nd ns-interval 0
 ipv6 nd dad attempts 1
 ipv6 nd prefix framed-ipv6-prefix
 ipv6 nd nud igp
 no ipv6 nd ra solicited unicast
 ipv6 nd ra lifetime 1800
 ipv6 nd ra interval 200
  ipv6 redirects
  ipv6 unreachables
 ipv6 mfib forwarding input
 ipv6 mfib forwarding output
 ipv6 mfib cef input
 ipv6 mfib cef output
 dot1q tunneling ethertype 0x8100
 no mab
 snmp trap link-status
 no onep application openflow exclusive
  cdp log mismatch duplex
 cdp tlv app
 arp arpa
 arp timeout 14400
 ethernet oam max-rate 10
 ethernet oam min-rate 1
 ethernet oam remote-loopback timeout 2
 ethernet oam timeout 5
 hold-queue 75 in
 hold-queue 40 out
 no bgp-policy accounting input
 no bgp-policy accounting output
 no bgp-policy accounting input source
 no bgp-policy accounting output source
 no bgp-policy source ip-prec-map
 no bgp-policy source ip-qos-map
 no bgp-policy destination ip-prec-map
 no bgp-policy destination ip-qos-map
```