### PR TITLE
add post-process-filter attribute to text parser

### DIFF
--- a/docs/yang/parsers/TextParser.rst
+++ b/docs/yang/parsers/TextParser.rst
@@ -36,6 +36,8 @@ Arguments:
  * **flat** (optional) if set to ``true`` (default is ``false``) the parser will understand the configuration for the
    element consists of flat commands instead of nested (for example BGP neighbors or static routes)
  * **key** (optional) set key manually
+ * **post_process_filter** (optional) - Modify the key with this Jinja expression. ``key`` and ``extra_vars``
+   variables are available.
 
 Example 1
 
@@ -144,6 +146,19 @@ Example 7
                   regexp: "(?P<block>ip route .*\n(?:.|\n)*?^!$)"
                   from: "{{ bookmarks['network-instances'][0] }}"
                   key: "static static"
+
+Example 8
+
+  Sometimes you need to transform the key value. For example, static routes require the prefix in CIDR format,
+  but Cisco IOS outputs routes in ``<network> <mask>`` format. In that case you can use ``post_process_filter`` to
+  apply additional filters::
+
+    static:
+        _process:
+            - mode: block
+               regexp: "(?P<block>ip route (?P<key>\\d+\\S+ \\d+\\S+).*)"
+               from: "{{ bookmarks['network-instances'][0] }}"
+               post_process_filter: "{{ key|addrmask_to_cidr }}"
 
 
 Leaf - search

--- a/docs/yang/parsers/XMLParser.rst
+++ b/docs/yang/parsers/XMLParser.rst
@@ -27,6 +27,7 @@ Arguments:
 
 * **xpath** (mandatory): elements to traverse
 * **key** (mandatory): which element is the key of the list
+* **post_process_filter** (optional): modify the key with this Jinja2 expression
 
 Example:
 

--- a/napalm_yang/helpers.py
+++ b/napalm_yang/helpers.py
@@ -9,7 +9,7 @@ from napalm_yang.translators.xml import XMLTranslator
 import os
 import jinja2
 
-from napalm_yang.jinja_filters import ip_filters
+from napalm_yang import jinja_filters
 
 import logging
 logger = logging.getLogger("napalm-yang")
@@ -131,7 +131,7 @@ def template(string, **kwargs):
                             undefined=jinja2.StrictUndefined,
                             keep_trailing_newline=True,
                             )
-    env.filters.update(ip_filters.filters())
+    env.filters.update(jinja_filters.load_filters())
 
     template = env.from_string(string)
 

--- a/napalm_yang/helpers.py
+++ b/napalm_yang/helpers.py
@@ -110,7 +110,11 @@ def resolve_rule(rule, attribute, keys, extra_vars=None, translation_model=None,
     kwargs["extra_vars"] = extra_vars
 
     for k, v in rule.items():
-        rule[k] = _resolve_rule(v, **kwargs)
+        if k.startswith('post_process_'):
+            # don't process post processing rules now, they'll be processed on a second pass
+            rule[k] = v
+        else:
+            rule[k] = _resolve_rule(v, **kwargs)
 
     if "when" in rule.keys():
         w = rule["when"]

--- a/napalm_yang/helpers.py
+++ b/napalm_yang/helpers.py
@@ -1,11 +1,4 @@
 import yaml
-
-from napalm_yang.parsers.text import TextParser
-from napalm_yang.parsers.xml import XMLParser
-
-from napalm_yang.translators.text import TextTranslator
-from napalm_yang.translators.xml import XMLTranslator
-
 import os
 import jinja2
 
@@ -24,16 +17,6 @@ def yaml_include(loader, node):
 
 
 yaml.add_constructor("!include", yaml_include)
-
-
-def get_parser(parser):
-    parsers = {
-        "TextParser": TextParser,
-        "XMLParser": XMLParser,
-        "TextTranslator": TextTranslator,
-        "XMLTranslator": XMLTranslator,
-    }
-    return parsers[parser]
 
 
 def find_yang_file(profile, filename, path):

--- a/napalm_yang/jinja_filters/__init__.py
+++ b/napalm_yang/jinja_filters/__init__.py
@@ -1,0 +1,16 @@
+import ip_filters
+
+JINJA_FILTERS = [
+    ip_filters,
+]
+
+
+def load_filters():
+    """
+    Loads and returns all filters.
+    """
+    all_filters = {}
+    for m in JINJA_FILTERS:
+        if hasattr(m, 'filters'):
+            all_filters.update(m.filters())
+    return all_filters

--- a/napalm_yang/jinja_filters/ip_filters.py
+++ b/napalm_yang/jinja_filters/ip_filters.py
@@ -5,6 +5,7 @@ def filters():
     return {
         "netmask_to_cidr": netmask_to_cidr,
         "cidr_to_netmask": cidr_to_netmask,
+        "addrmask_to_cidr": addrmask_to_cidr,
     }
 
 
@@ -26,3 +27,15 @@ def cidr_to_netmask(value):
         >>> "{{ '24'|cidr_to_netmask }}" -> "255.255.255.0"
     """
     return netaddr.IPNetwork("1.1.1.1/{}".format(value)).netmask
+
+
+def addrmask_to_cidr(value):
+    """
+    Converts an address and network mask to it's CIDR representation.
+
+    Examples:
+        >>> "{{ '192.168.0.0 255.255.255.0'|addrmask_to_cidr }}" -> "192.168.0.0/24"
+    """
+    value = value.replace(' ', '/')
+    return str(netaddr.IPNetwork(value))
+

--- a/napalm_yang/parser.py
+++ b/napalm_yang/parser.py
@@ -2,6 +2,7 @@ import os
 import copy
 
 from napalm_yang import helpers
+from napalm_yang.parsers import get_parser
 
 import logging
 logger = logging.getLogger("napalm-yang")
@@ -49,7 +50,7 @@ class Parser(object):
         self.bookmarks = bookmarks or self.bookmarks
 
         if self.mapping:
-            self.parser = helpers.get_parser(self.mapping["metadata"]["processor"])
+            self.parser = get_parser(self.mapping["metadata"]["processor"])
 
     def _execute_methods(self, device, methods):
         result = []

--- a/napalm_yang/parsers/__init__.py
+++ b/napalm_yang/parsers/__init__.py
@@ -1,0 +1,15 @@
+from napalm_yang.parsers.text import TextParser
+from napalm_yang.parsers.xml import XMLParser
+
+from napalm_yang.translators.text import TextTranslator
+from napalm_yang.translators.xml import XMLTranslator
+
+
+def get_parser(parser):
+    parsers = {
+        "TextParser": TextParser,
+        "XMLParser": XMLParser,
+        "TextTranslator": TextTranslator,
+        "XMLTranslator": XMLTranslator,
+    }
+    return parsers[parser]

--- a/napalm_yang/parsers/base.py
+++ b/napalm_yang/parsers/base.py
@@ -1,3 +1,4 @@
+from napalm_yang.helpers import template
 
 
 class BaseParser(object):
@@ -54,6 +55,14 @@ class BaseParser(object):
     def _parse_container_gate(cls, mapping):
         """This basically stops parsing the tree by returning None"""
         return None, {}
+
+    @classmethod
+    def _parse_post_process_filter(cls, post_process_filter, key, extra_vars={}):
+        kwargs = dict()
+        kwargs['key'] = key
+        kwargs["extra_vars"] = extra_vars
+        key = template(post_process_filter, **kwargs)
+        return key
 
     """
     @classmethod

--- a/napalm_yang/parsers/text.py
+++ b/napalm_yang/parsers/text.py
@@ -1,5 +1,4 @@
 from napalm_yang.parsers.base import BaseParser
-from napalm_yang.helpers import template
 
 import itertools
 
@@ -33,10 +32,7 @@ class TextParser(BaseParser):
                     key = extra_vars.pop("key")
 
                 if post_process_filter:
-                    kwargs = dict()
-                    kwargs['key'] = key
-                    kwargs["extra_vars"] = extra_vars
-                    key = template(post_process_filter, **kwargs)
+                    key = cls._parse_post_process_filter(post_process_filter, key, extra_vars)
 
                 extra_vars["_get_duplicates"] = mapping.get("flat", False)
 

--- a/napalm_yang/parsers/text.py
+++ b/napalm_yang/parsers/text.py
@@ -1,4 +1,5 @@
 from napalm_yang.parsers.base import BaseParser
+from napalm_yang import jinja_filters
 
 import itertools
 
@@ -19,6 +20,7 @@ class TextParser(BaseParser):
             else:
                 composite_key = mapping.get("composite_key", None)
                 forced_key = mapping.get("key", None)
+                post_process_filter = mapping.get("post_process_filter", None)
 
                 extra_vars = match.groupdict()
                 block = extra_vars.pop("block")
@@ -29,6 +31,9 @@ class TextParser(BaseParser):
                     key = forced_key
                 else:
                     key = extra_vars.pop("key")
+
+                if post_process_filter:
+                    key = jinja_filters.load_filters().get(post_process_filter)(key)
 
                 extra_vars["_get_duplicates"] = mapping.get("flat", False)
 

--- a/napalm_yang/parsers/text.py
+++ b/napalm_yang/parsers/text.py
@@ -1,4 +1,5 @@
 from napalm_yang.parsers.base import BaseParser
+from napalm_yang.helpers import template
 
 import itertools
 
@@ -32,7 +33,6 @@ class TextParser(BaseParser):
                     key = extra_vars.pop("key")
 
                 if post_process_filter:
-                    from napalm_yang.helpers import template
                     kwargs = dict()
                     kwargs['key'] = key
                     kwargs["extra_vars"] = extra_vars

--- a/napalm_yang/parsers/text.py
+++ b/napalm_yang/parsers/text.py
@@ -1,5 +1,4 @@
 from napalm_yang.parsers.base import BaseParser
-from napalm_yang import jinja_filters
 
 import itertools
 
@@ -33,7 +32,11 @@ class TextParser(BaseParser):
                     key = extra_vars.pop("key")
 
                 if post_process_filter:
-                    key = jinja_filters.load_filters().get(post_process_filter)(key)
+                    from napalm_yang.helpers import template
+                    kwargs = dict()
+                    kwargs['key'] = key
+                    kwargs["extra_vars"] = extra_vars
+                    key = template(post_process_filter, **kwargs)
 
                 extra_vars["_get_duplicates"] = mapping.get("flat", False)
 

--- a/napalm_yang/parsers/xml.py
+++ b/napalm_yang/parsers/xml.py
@@ -14,12 +14,15 @@ class XMLParser(BaseParser):
         xml = etree.fromstring(mapping["from"])
 
         mandatory_elements = mapping.pop("mandatory", [])
+        post_process_filter = mapping.pop("post_process_filter", None)
 
         for element in itertools.chain(xml.xpath(mapping["xpath"]), mandatory_elements):
             if isinstance(element, dict):
                 yield element["key"], element["block"], element["extra_vars"]
             else:
                 key = element.xpath(mapping["key"])[0].text.strip()
+                if post_process_filter:
+                    key = cls._parse_post_process_filter(post_process_filter, key)
                 yield key, etree.tostring(element), {}
 
     @classmethod

--- a/napalm_yang/translator.py
+++ b/napalm_yang/translator.py
@@ -1,4 +1,5 @@
 from napalm_yang import helpers
+from napalm_yang.parsers import get_parser
 
 
 import logging
@@ -27,7 +28,7 @@ class Translator(object):
                                              self.profile, "translators")
 
         if self.mapping:
-            translator = helpers.get_parser(self.mapping["metadata"]["processor"])
+            translator = get_parser(self.mapping["metadata"]["processor"])
             self.translator = translator(merge=bool(merge), replace=bool(replace))
 
             if translation is None:


### PR DESCRIPTION
As discussed on NTC slack.

Just the most basic version for now. Looking forward for notes :)

One thing that came to mind would be ability to pass arguments to jinja filters in DSL. And support the same syntax as Jinja2. Something like:

```
- mode: block
  regexp: "(?P<block>router (?P<key>.+))^!$"
  post_process_filter: "truncate(64)"
```
Where `truncate` is the name of the filter called and `64` would be an extra argument passed to it along with the key.

What do you think?
