### PR TITLE
Add args and kwargs support to method execution

### DIFF
--- a/docs/yang/parsers.rst
+++ b/docs/yang/parsers.rst
@@ -183,13 +183,15 @@ the device. For example::
         parser: XMLParser
         execute:
             - method: _rpc
-              args:
+              args: []
+              kwargs:
                   get: "<get-configuration/>"
 
 * **execute** is a list of calls to do to from the device to extract the data.
 
   * **method** is the method from the device to call.
-  * **args** are arguments that will be passed to the method.
+  * **args** are the numbered/ordered arguments for the method
+  * **kwargs** are the keyword arguments for the method
 
 In addition, some methods like ``parse_config`` and ``parse_state`` may have mechanisms to pass the
 information needed to the parser instead of relying on a live device to obtain it. For parsers, you

--- a/docs/yang/writing_profiles.rst
+++ b/docs/yang/writing_profiles.rst
@@ -49,12 +49,13 @@ If we check the content of the file ``vlan.yaml`` we can clearly see two parts:
         processor: XMLParser
         execute:
             - method: _rpc
-              args:
+              args: []
+              kwargs:
                   get: "<get-configuration/>"
 
 In this case we are using the ``XMLParser`` parser and in order to get the data we need from the
-device we have to call the method ``_rpc`` with the ``args`` parameters. This is, by the way, an
-RPC call for a junos device.
+device we have to call the method ``_rpc`` with the ``args`` and ``kwargs`` parameters. This is, 
+by the way, an RPC call for a junos device.
 
 * **vlan** - This is the part that follows the model specification. In this case is ``vlan`` but in
   others it might be ``interfaces``, ``addressess`` or something else, this will be model dependent

--- a/napalm_yang/mappings/eos/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/eos/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -3,7 +3,7 @@ metadata:
     processor: TextParser
     execute:
         - method: cli
-          args:
+          kwargs:
               commands: ["show running-config all"]
 interfaces:
     _process: unnecessary

--- a/napalm_yang/mappings/eos/parsers/config/openconfig-network-instance/network-instances.yaml
+++ b/napalm_yang/mappings/eos/parsers/config/openconfig-network-instance/network-instances.yaml
@@ -3,7 +3,7 @@ metadata:
     processor: TextParser
     execute:
         - method: cli
-          args:
+          kwargs:
               commands: ["show running-config all"]
 
 network-instances:

--- a/napalm_yang/mappings/eos/parsers/state/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/eos/parsers/state/openconfig-interfaces/interfaces.yaml
@@ -3,7 +3,7 @@ metadata:
     processor: JSONParser
     execute:
         - method: "device.run_commands"
-          args:
+          kwargs:
               commands: ["show interfaces", "show snmp mib ifmib ifindex"]
 
 interfaces:

--- a/napalm_yang/mappings/ios/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/ios/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -3,7 +3,7 @@ metadata:
     processor: TextParser
     execute:
         - method: cli
-          args:
+          kwargs:
               commands: ["show running-config all"]
 interfaces:
     _process: unnecessary

--- a/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -3,7 +3,7 @@ metadata:
     processor: XMLParser
     execute:
         - method: _rpc
-          args:
+          kwargs:
               get: "<get-configuration/>"
 
 interfaces:

--- a/napalm_yang/mappings/junos/parsers/config/openconfig-network-instance/network-instances.yaml
+++ b/napalm_yang/mappings/junos/parsers/config/openconfig-network-instance/network-instances.yaml
@@ -3,7 +3,7 @@ metadata:
     processor: XMLParser
     execute:
         - method: _rpc
-          args:
+          kwargs:
               get: "<get-configuration/>"
 
 network-instances:

--- a/napalm_yang/mappings/junos/parsers/state/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/junos/parsers/state/openconfig-interfaces/interfaces.yaml
@@ -3,7 +3,7 @@ metadata:
     processor: XMLParser
     execute:
         - method: _rpc
-          args:
+          kwargs:
               get: "<get-interface-information><extensive/></get-interface-information>"
 
 interfaces:

--- a/napalm_yang/mappings/templates/parsers/state/openconfig-platform/components.yaml
+++ b/napalm_yang/mappings/templates/parsers/state/openconfig-platform/components.yaml
@@ -3,7 +3,8 @@ metadata:
     parser:
     execute:
         - method:
-          args:
+          args: []
+          kwargs:
               commands: [ ]
 
 components:

--- a/napalm_yang/parser.py
+++ b/napalm_yang/parser.py
@@ -56,9 +56,15 @@ class Parser(object):
         result = []
         for m in methods:
             attr = device
+            args = []
+            kwargs = {}
             for p in m["method"].split("."):
                 attr = getattr(attr, p)
-            r = attr(**m["args"])
+            if isinstance(m.get("args", None), list):
+                args = m["args"]
+            if isinstance(m.get("kwargs", None), dict):
+                kwargs = m["kwargs"]
+            r = attr(*args, **kwargs)
 
             if isinstance(r, dict) and all([isinstance(x, (str, unicode)) for x in r.values()]):
                 # Some vendors like junos return commands enclosed by a key

--- a/napalm_yang/parser.py
+++ b/napalm_yang/parser.py
@@ -56,14 +56,14 @@ class Parser(object):
         result = []
         for m in methods:
             attr = device
-            args = []
-            kwargs = {}
             for p in m["method"].split("."):
                 attr = getattr(attr, p)
-            if isinstance(m.get("args", None), list):
-                args = m["args"]
-            if isinstance(m.get("kwargs", None), dict):
-                kwargs = m["kwargs"]
+            args = m.get("args", [])
+            if not isinstance(args, list):
+                raise TypeError("args must be type list, not type {}".format(type(args)))
+            kwargs = m.get("kwargs", {})
+            if not isinstance(args, dict):
+                raise TypeError("kwargs must be type dict, not type {}".format(type(kwargs)))
             r = attr(*args, **kwargs)
 
             if isinstance(r, dict) and all([isinstance(x, (str, unicode)) for x in r.values()]):


### PR DESCRIPTION
Noticed that there wasn't a way to run a method that took no arguments.  Updated parse.py to support *args, **kwargs format.

Further testing probably required.