### PR TITLE
BaseTranslator.default_element() needs to return a dict

### DIFF
--- a/napalm_yang/translators/base.py
+++ b/napalm_yang/translators/base.py
@@ -45,7 +45,7 @@ class BaseTranslator(object):
             if mode == "skip":
                 continue
             elif mode == "gate":
-                return
+                return {}
 
             t = _find_translation_point(m, bookmarks, t)
             method_name = "_default_element_{}".format(mode)


### PR DESCRIPTION
or we'll sometimes crash:

```
In [117]: print(candidate.translate_config(profile=['ios'], replace=running))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-117-63278185d7d2> in <module>()
----> 1 print(candidate.translate_config(profile=['ios'], replace=running))

...

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/translator.pyc in _default_element_list(self, attribute, running, mapping, translation, candidate)
    171                 extra_vars = self.translator.default_element(translation_rule, translation,
    172                                                              self.bookmarks)
--> 173                 self.extra_vars.update(extra_vars)
    174 
    175                 if any([t.get("continue_negating", False) for t in translation_rule]):

TypeError: 'NoneType' object is not iterable
```
