### PR TITLE
Jinja ip filters should not raise an exception if passed an undefined value

### DIFF
--- a/napalm_yang/jinja_filters/helpers.py
+++ b/napalm_yang/jinja_filters/helpers.py
@@ -1,0 +1,16 @@
+def check_empty(filter_function):
+    """
+    Decorator that checks if a value passed to a Jinja filter evaluates to false
+    and returns an empty string. Otherwise calls the original Jinja filter.
+
+    Example usage:
+    @check_empty
+    def my_jinja_filter(value, arg1):
+    """
+    def wrapper(value, *args, **kwargs):
+        if not value:
+            return ''
+        else:
+            return filter_function(value, *args, **kwargs)
+
+    return wrapper

--- a/napalm_yang/jinja_filters/ip_filters.py
+++ b/napalm_yang/jinja_filters/ip_filters.py
@@ -1,5 +1,7 @@
 import netaddr
 
+from napalm_yang.jinja_filters.helpers import check_empty
+
 
 def filters():
     return {
@@ -9,20 +11,6 @@ def filters():
         "normalize_address": normalize_address,
         "prefix_to_addrmask": prefix_to_addrmask,
     }
-
-
-def check_empty(filter_function):
-    """
-    Checks if a value passed to a Jinja filter evaluates to false and returns an empty string.
-    Otherwise calls the original Jinja filter.
-    """
-    def wrapper(value, *args, **kwargs):
-        if not value:
-            return ''
-        else:
-            return filter_function(value, *args, **kwargs)
-
-    return wrapper
 
 
 @check_empty

--- a/napalm_yang/jinja_filters/ip_filters.py
+++ b/napalm_yang/jinja_filters/ip_filters.py
@@ -18,7 +18,10 @@ def netmask_to_cidr(value):
     Examples:
         >>> "{{ '255.255.255.0'|netmask_to_cidr }}" -> "24"
     """
-    return netaddr.IPAddress(value).netmask_bits()
+    if not value:
+        return ''
+    else:
+        return netaddr.IPAddress(value).netmask_bits()
 
 
 def cidr_to_netmask(value):
@@ -28,7 +31,10 @@ def cidr_to_netmask(value):
     Examples:
         >>> "{{ '24'|cidr_to_netmask }}" -> "255.255.255.0"
     """
-    return str(netaddr.IPNetwork("1.1.1.1/{}".format(value)).netmask)
+    if not value:
+        return ''
+    else:
+        return str(netaddr.IPNetwork("1.1.1.1/{}".format(value)).netmask)
 
 
 def normalize_prefix(value):
@@ -43,8 +49,11 @@ def normalize_prefix(value):
         >>> "{{ '192.168/255.255.255.0'|normalize_prefix }}" -> "192.168.0.0/24"
         >>> "{{ '2001:DB8:0:0:1:0:0:1/64'|normalize_prefix }}" -> "2001:db8::1:0:0:1/64"
     """
-    value = value.replace(' ', '/')
-    return str(netaddr.IPNetwork(value))
+    if not value:
+        return ''
+    else:
+        value = value.replace(' ', '/')
+        return str(netaddr.IPNetwork(value))
 
 
 def normalize_address(value):
@@ -60,7 +69,10 @@ def normalize_address(value):
         >>> "{{ '2001:DB8:0:0:1:0:0:1'|normalize_address }}" -> "2001:db8::1:0:0:1"
 
     """
-    return str(netaddr.IPAddress(value))
+    if not value:
+        return ''
+    else:
+        return str(netaddr.IPAddress(value))
 
 
 def prefix_to_addrmask(value, sep=' '):
@@ -73,5 +85,8 @@ def prefix_to_addrmask(value, sep=' '):
         >>> "{{ '192.168.0.1/24|prefix_to_addrmask }}" -> "192.168.0.1 255.255.255.0"
         >>> "{{ '192.168.0.1/24|prefix_to_addrmask('/') }}" -> "192.168.0.1/255.255.255.0"
     """
-    prefix = netaddr.IPNetwork(value)
-    return '{}{}{}'.format(prefix.ip, sep, prefix.netmask)
+    if not value:
+        return ''
+    else:
+        prefix = netaddr.IPNetwork(value)
+        return '{}{}{}'.format(prefix.ip, sep, prefix.netmask)

--- a/napalm_yang/jinja_filters/ip_filters.py
+++ b/napalm_yang/jinja_filters/ip_filters.py
@@ -14,7 +14,7 @@ def filters():
 def check_empty(filter_function):
     """
     Checks if a value passed to a Jinja filter evaluates to false and returns an empty string.
-    Otherwise calls the original Junja filter.
+    Otherwise calls the original Jinja filter.
     """
     def wrapper(value, *args, **kwargs):
         if not value:

--- a/napalm_yang/jinja_filters/ip_filters.py
+++ b/napalm_yang/jinja_filters/ip_filters.py
@@ -11,6 +11,21 @@ def filters():
     }
 
 
+def check_empty(filter_function):
+    """
+    Checks if a value passed to a Jinja filter evaluates to false and returns an empty string.
+    Otherwise calls the original Junja filter.
+    """
+    def wrapper(value, *args, **kwargs):
+        if not value:
+            return ''
+        else:
+            return filter_function(value, *args, **kwargs)
+
+    return wrapper
+
+
+@check_empty
 def netmask_to_cidr(value):
     """
     Converts a network mask to it's CIDR value.
@@ -18,12 +33,10 @@ def netmask_to_cidr(value):
     Examples:
         >>> "{{ '255.255.255.0'|netmask_to_cidr }}" -> "24"
     """
-    if not value:
-        return ''
-    else:
-        return netaddr.IPAddress(value).netmask_bits()
+    return netaddr.IPAddress(value).netmask_bits()
 
 
+@check_empty
 def cidr_to_netmask(value):
     """
     Converts a CIDR prefix-length to a network mask.
@@ -31,12 +44,10 @@ def cidr_to_netmask(value):
     Examples:
         >>> "{{ '24'|cidr_to_netmask }}" -> "255.255.255.0"
     """
-    if not value:
-        return ''
-    else:
-        return str(netaddr.IPNetwork("1.1.1.1/{}".format(value)).netmask)
+    return str(netaddr.IPNetwork("1.1.1.1/{}".format(value)).netmask)
 
 
+@check_empty
 def normalize_prefix(value):
     """
     Converts an IPv4 or IPv6 prefix writen in various formats to its CIDR representation.
@@ -49,13 +60,11 @@ def normalize_prefix(value):
         >>> "{{ '192.168/255.255.255.0'|normalize_prefix }}" -> "192.168.0.0/24"
         >>> "{{ '2001:DB8:0:0:1:0:0:1/64'|normalize_prefix }}" -> "2001:db8::1:0:0:1/64"
     """
-    if not value:
-        return ''
-    else:
-        value = value.replace(' ', '/')
-        return str(netaddr.IPNetwork(value))
+    value = value.replace(' ', '/')
+    return str(netaddr.IPNetwork(value))
 
 
+@check_empty
 def normalize_address(value):
     """
     Converts an IPv4 or IPv6 address writen in various formats to a standard textual representation.
@@ -69,12 +78,10 @@ def normalize_address(value):
         >>> "{{ '2001:DB8:0:0:1:0:0:1'|normalize_address }}" -> "2001:db8::1:0:0:1"
 
     """
-    if not value:
-        return ''
-    else:
-        return str(netaddr.IPAddress(value))
+    return str(netaddr.IPAddress(value))
 
 
+@check_empty
 def prefix_to_addrmask(value, sep=' '):
     """
     Converts a CIDR formatted prefix into an address netmask representation.
@@ -85,8 +92,5 @@ def prefix_to_addrmask(value, sep=' '):
         >>> "{{ '192.168.0.1/24|prefix_to_addrmask }}" -> "192.168.0.1 255.255.255.0"
         >>> "{{ '192.168.0.1/24|prefix_to_addrmask('/') }}" -> "192.168.0.1/255.255.255.0"
     """
-    if not value:
-        return ''
-    else:
-        prefix = netaddr.IPNetwork(value)
-        return '{}{}{}'.format(prefix.ip, sep, prefix.netmask)
+    prefix = netaddr.IPNetwork(value)
+    return '{}{}{}'.format(prefix.ip, sep, prefix.netmask)

--- a/test/unit/test_jinja_filters.py
+++ b/test/unit/test_jinja_filters.py
@@ -25,6 +25,7 @@ class TestJinjaFilters(unittest.TestCase):
         Tests Jinja2 filter ```netmask_to_cidr```:
 
             * check if load_filters returns the correct function
+            * check if returns empty string on None
             * check if raises AddrFormatError on invalid mask
             * check if prefix length is returned as expected
         """
@@ -35,6 +36,7 @@ class TestJinjaFilters(unittest.TestCase):
 
         self.assertRaises(AddrFormatError, ip_filters.netmask_to_cidr, 'bad')
 
+        self.assertEqual(ip_filters.netmask_to_cidr(None), '')
         self.assertEqual(ip_filters.netmask_to_cidr('255.255.255.0'), 24)
         self.assertEqual(ip_filters.netmask_to_cidr('255.255.255.255'), 32)
 
@@ -43,6 +45,7 @@ class TestJinjaFilters(unittest.TestCase):
         Tests Jinja2 filter ```cidr_to_netmask```:
 
             * check if load_filters returns the correct function
+            * check if returns empty string on None
             * check if raises AddrFormatError on invalid prefix length
             * check if network mask is returned as expected
         """
@@ -53,6 +56,7 @@ class TestJinjaFilters(unittest.TestCase):
 
         self.assertRaises(AddrFormatError, ip_filters.cidr_to_netmask, 'bad')
 
+        self.assertEqual(ip_filters.cidr_to_netmask(None), '')
         self.assertEqual(ip_filters.cidr_to_netmask(24), '255.255.255.0')
         self.assertEqual(ip_filters.cidr_to_netmask('24'), '255.255.255.0')
         self.assertEqual(ip_filters.cidr_to_netmask(32), '255.255.255.255')
@@ -62,6 +66,7 @@ class TestJinjaFilters(unittest.TestCase):
         Tests Jinja2 filter ```normalize_prefix```:
 
             * check if load_filters returns the correct function
+            * check if returns empty string on None
             * check if raises AddrFormatError on invalid prefix
             * check if IPv4 and IPv6 prefix format is returned as expected
         """
@@ -72,6 +77,7 @@ class TestJinjaFilters(unittest.TestCase):
 
         self.assertRaises(AddrFormatError, ip_filters.normalize_prefix, 'bad')
 
+        self.assertEqual(ip_filters.normalize_prefix(None), '')
         self.assertEqual(ip_filters.normalize_prefix('192.168.0.1'), '192.168.0.1/32')
         self.assertEqual(ip_filters.normalize_prefix('192.168.0.55 255.255.255.0'),
                          '192.168.0.55/24')
@@ -85,6 +91,7 @@ class TestJinjaFilters(unittest.TestCase):
         Tests Jinja2 filter ```normalize_address```:
 
             * check if load_filters returns the correct function
+            * check if returns empty string on None
             * check if raises AddrFormatError on invalid address
             * check if IPv4 and IPv6 address format is returned as expected
         """
@@ -95,6 +102,7 @@ class TestJinjaFilters(unittest.TestCase):
 
         self.assertRaises(AddrFormatError, ip_filters.normalize_address, 'bad')
 
+        self.assertEqual(ip_filters.normalize_address(None), '')
         self.assertEqual(ip_filters.normalize_address('192.168.0.1'), '192.168.0.1')
         self.assertEqual(ip_filters.normalize_address('192.168.1'), '192.168.0.1')
         self.assertEqual(ip_filters.normalize_address('2001:0DB8:0:0000:1:0:0:1'),
@@ -105,6 +113,7 @@ class TestJinjaFilters(unittest.TestCase):
         Tests Jinja2 filter ```prefix_to_addrmask```:
 
             * check if load_filters returns the correct function
+            * check if returns empty string on None
             * check if raises AddrFormatError on invalid prefix
             * check if IPv4 address and netmask format is returned as expected
         """
@@ -115,6 +124,7 @@ class TestJinjaFilters(unittest.TestCase):
 
         self.assertRaises(AddrFormatError, ip_filters.prefix_to_addrmask, 'bad')
 
+        self.assertEqual(ip_filters.prefix_to_addrmask(None), '')
         self.assertEqual(ip_filters.prefix_to_addrmask('192.168.0.1/24'),
                          '192.168.0.1 255.255.255.0')
         self.assertEqual(ip_filters.prefix_to_addrmask('192.168.0.0/32', '/'),


### PR DESCRIPTION
While writing parsers I have cases like this:

```
                        - mode: value
                          value: "{{ extra_vars.next_hop|normalize_address }}"
                          when: "{{ extra_vars.next_hop is not none }}"
```

Both Jinja templates are evaluated before a decision defined in `when` is made. If `extra_vars.next_hop` is None the normalize_address filter crashes.

I modified existing filters to return an empty string when a value passed in evaluates to False.
