### PR TITLE
fix parsing bgp neighbor shutdown on eos

### DIFF
--- a/napalm_yang/mappings/eos/parsers/config/openconfig-network-instance/includes/bgp.yaml
+++ b/napalm_yang/mappings/eos/parsers/config/openconfig-network-instance/includes/bgp.yaml
@@ -623,7 +623,8 @@ neighbors:
             enabled:
                 _process:
                     - mode: is_absent
-                      regexp: "neighbor {{ neighbor_key }} (?P<value>shutdown)"
+                      regexp: "^\\s*neighbor {{ neighbor_key }} (?P<value>shutdown)"
+                      from: "protocol.{{protocol_key}}"
             local-as:
                 _process:
                     - regexp: "neighbor {{ neighbor_key }} local-as (?P<value>\\d+)"


### PR DESCRIPTION
Current mapping for `/network-instances/network-instance[name='global']/protocols/protocol[identifier='bgp' name='bgp']/bgp/neighbors/neighbor[neighbor-address='192.168.0.200']/config/enabled` doesn't work as expected. It will always set to the result of the last line of configuration for a given BGP neighbor.

So given this:

```
   neighbor 192.168.0.200 shutdown
   neighbor 192.168.0.200 remove-private-as
```

The first line will set enabled to False and the second back to True.

Part of the issue is that we are using [`flat: true`](https://github.com/napalm-automation/napalm-yang/blob/develop/napalm_yang/mappings/eos/parsers/config/openconfig-network-instance/includes/bgp.yaml#L355) so each configuration line is its own block. But we need that to parse all the `neighbor [address] .*` statements under the same key.

So I changed it to parse `from: "protocol.{{protocol_key}}"`. Also we shouldn't interpret `no neighbor 192.168.0.200 shutdown` as being disabled.

There are still issues when doing candidate.translate(merge=running) when going from `enabled: false` to `enabled: true`. I'll see if I can fix that later.
