### PR TITLE
don't crash when using nested key flattening

### DIFF
--- a/napalm_yang/parsers/base.py
+++ b/napalm_yang/parsers/base.py
@@ -39,6 +39,9 @@ class BaseParser(object):
                 for k, v in iterator:
                     if k.startswith("#"):
                         continue
+                    if not isinstance(v, dict):
+                        result.append((k, v))
+                        continue
                     r = self.resolve_path(v, ".".join(path_split), default, check_presence)
                     if not r:
                         break

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -51,6 +51,7 @@ class Tests(object):
                 processed = True
                 parser.keys = d["keys"]
                 parser.extra_vars = d["extra_vars"]
+                bookmarks.update(d.get("bookmarks", {}))
                 i = 0
                 for k, b, e in parser.parse_list(attribute, example["rule"], bookmarks):
                     assert k == example["expected"][case][i]["key"]

--- a/test/unit/test_parser/006_ios_ip_route/example.yaml
+++ b/test/unit/test_parser/006_ios_ip_route/example.yaml
@@ -1,0 +1,159 @@
+---
+documentation:
+    title: Parsing static route next-hop on IOS (flattening flattened keys)
+    summary: |
+        We've used this rule to parse the IP prefix part of a static route::
+
+            - path: "ip.route.?prefix.?mask"
+              regexp: "^(?P<value>\\d+\\.\\d+\\.\\d+\\.\\d+\\/\\d+)$"
+              key: "{{ prefix }}/{{ mask|netmask_to_cidr }}"
+
+        This gave us the data that looks like this::
+
+            ip:
+              route:
+                1.1.1.0:
+                  255.255.255.0:
+                    FastEthernet0/1:
+                      10.1.1.1:
+                        '#standalone': true
+                    mask: 255.255.255.0
+                    prefix: 1.1.1.0
+                2.2.2.0:
+                  255.255.255.0:
+                    FastEthernet0/2:
+                      '#standalone': true
+                    mask: 255.255.255.0
+                    prefix: 2.2.2.0
+                3.3.3.0:
+                  255.255.255.0:
+                    10.1.1.3:
+                      '#standalone': true
+                    mask: 255.255.255.0
+                    prefix: 3.3.3.0
+
+        Now we need to parse the next-hop value. This can be specified three
+        different ways:
+
+        - ``[output_interface] [next_hop_address]``
+        - ``[output_interface]``
+        - ``[next_hop_address]``
+
+        We'll need to use multiple parser rules to parse all three variants.
+    rule: |
+        The first rule will cover the first variant. It will flatten the first
+        and second level keys into keys ``interface_ref`` and ``next_hop_addr``.
+        The ``regex`` ensures that we only match values that look like IOS
+        interface names and IPv4 or IPv6 addresses.
+
+        The second rule covers the second variant. The ``when`` expression
+        ensures it will only be processed if the previous rule did not match.
+        (FIXME - runs always) It will flatten the first level key into ``interface_ref``.
+        The ``regex`` will only match values that look like IOS interface names.
+
+        The third rule is similar to the second. It will flatten the first key
+        into ``next_hop_addr`` variable and match it to an IPv4 or IPv6 address.
+        This covers the third variant.
+
+        ``regex`es will also capture the relevant interface and address values
+        into their respective variables so they are available for use later in
+        the tree.
+    result: ""
+
+processor:
+    name: TextTree
+    attribute: next-hop
+    root_name: network-instances
+    node_type: list
+    mode: config
+data:
+    - keys:
+        network_instance_key: global
+        parent_key: 1.1.1.0/24
+        static_key: 1.1.1.0/24
+      extra_vars:
+        parent:
+          value: 1.1.1.0/24
+        static:
+          value: 1.1.1.0/24
+      bookmarks:
+        parent:
+          '#text': FastEthernet0/1 10.1.1.1
+          FastEthernet0/1:
+            '#text': 10.1.1.1
+            10.1.1.1:
+              '#standalone': true
+          mask: 255.255.255.0
+          prefix: 1.1.1.0
+    - keys:
+        network_instance_key: global
+        parent_key: 2.2.2.0/24
+        static_key: 2.2.2.0/24
+      extra_vars:
+        next-hop:
+          value: FastEthernet0/1 10.1.1.1
+        parent:
+          value: 2.2.2.0/24
+        static:
+          value: 2.2.2.0/24
+      bookmarks:
+        parent:
+          '#text': FastEthernet0/2
+          FastEthernet0/2:
+            '#standalone': true
+          mask: 255.255.255.0
+          prefix: 2.2.2.0
+    - keys:
+        network_instance_key: global
+        parent_key: 3.3.3.0/24
+        static_key: 3.3.3.0/24
+      extra_vars:
+        next-hop:
+          value: FastEthernet0/2
+        parent:
+          value: 3.3.3.0/24
+        static:
+          value: 3.3.3.0/24
+      bookmarks:
+        parent:
+          '#text': 10.1.1.3
+          10.1.1.3:
+            '#standalone': true
+          mask: 255.255.255.0
+          prefix: 3.3.3.0
+rule:
+    - path: "?interface_ref.?next_hop_addr"
+      regexp: "^(?P<value>(?P<interface_ref>[a-zA-Z][\\w\\-/]+(?::\\d+)?(?:\\.\\d+)?)\\s(?P<next_hop_addr>(?:\\d+\\.\\d+\\.\\d+\\.\\d+|[0-9a-fA-F:]+:[0-9a-fA-F:]+)))$"
+      key: "{{ interface_ref }} {{ next_hop_addr|normalize_address }}"
+    - path: "?interface_ref"
+      regexp: "^(?P<value>(?P<interface_ref>[a-zA-Z][\\w\\-/]+(?::\\d+)?(?:\\.\\d+)?))$"
+      key: "{{ interface_ref }}"
+    - path: "?next_hop_addr"
+      regexp: "^(?P<value>(?P<next_hop_addr>(?:\\d+\\.\\d+\\.\\d+\\.\\d+|[0-9a-fA-F:]+:[0-9a-fA-F:]+)))$"
+      key: "{{ next_hop_addr|normalize_address }}"
+
+expected:
+    - - key: FastEthernet0/1 10.1.1.1
+        block:
+          '#standalone': true
+          interface_ref: FastEthernet0/1
+          next_hop_addr: 10.1.1.1
+        extra_vars:
+          interface_ref: FastEthernet0/1
+          next_hop_addr: 10.1.1.1
+          value: FastEthernet0/1 10.1.1.1
+    - - key: FastEthernet0/2
+        block:
+          '#standalone': true
+          interface_ref: FastEthernet0/2
+        extra_vars:
+          interface_ref: FastEthernet0/2
+          value: FastEthernet0/2
+    - - key: 10.1.1.3
+        block:
+          '#standalone': true
+          interface_ref: 10.1.1.3
+          next_hop_addr: 10.1.1.3
+        extra_vars:
+          next_hop_addr: 10.1.1.3
+          value: 10.1.1.3

--- a/test/unit/test_parser/006_ios_ip_route/mocked.txt
+++ b/test/unit/test_parser/006_ios_ip_route/mocked.txt
@@ -1,0 +1,3 @@
+ip route 1.1.1.0 255.255.255.0 FastEthernet0/1 10.1.1.1
+ip route 2.2.2.0 255.255.255.0 FastEthernet0/2
+ip route 3.3.3.0 255.255.255.0 10.1.1.3


### PR DESCRIPTION
When using one multiple instances of nested key flattening, the parser will crash on the second instance.

[Example](https://github.com/ArnesSI/napalm-yang/blob/38e27120b5ea78e5a996cc1a66ed577f079e01e7/napalm_yang/mappings/ios/parsers/config/openconfig-network-instance/includes/static_routes.yaml):

```yaml
static:
    _process:
        - path: "?prefix.?mask"
...
  next-hops:
        _process: unnecessary
        next-hop:
            _process:
                - path: "?interface_ref.?next_hop_addr"
...
```

Added two prints to `jsonp.py` to make the problem stand out a bit more:

```python
        print('PRE ', attribute, mapping.get("path", ""), data) 
        d = self.resolve_path(data, mapping.get("path", ""), mapping.get("default")) 
        print('POST', attribute, mapping.get("path", ""), d) 
```

Error:

```Python traceback
DEBUG:napalm-yang:Parsing element protocol[static static]
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/bgp
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/bgp
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/state
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/local-aggregates
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/local-aggregates
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/name
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/name
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes/static
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes/static
('PRE ', 'static', '?prefix.?mask', OrderedDict([('#text', 'vrf mgmtVrf 5.5.5.5 255.255.255.255 FastEthernet1 192.168.5.5'), ('1.1.1.1', OrderedDict([('#text', '255.255.255.255 Null0 tag 555'), ('255.255.255.255', OrderedDict([('#text', 'Null0 tag 555'), ('Null0', OrderedDict([('#text', 'tag 555'), ('tag', OrderedDict([('#text', '555'), ('555', OrderedDict([('#standalone', True)]))]))]))]))])), ('2.2.2.2', OrderedDict([('#text', '255.255.255.255 10.1.1.1'), ('255.255.255.255', OrderedDict([('#text', '10.1.1.1'), ('10.1.1.1', OrderedDict([('#standalone', True)]))]))])), ('3.3.3.0', OrderedDict([('#text', '255.255.255.0 Vlan798 10.4.4.4 66'), ('255.255.255.0', OrderedDict([('#text', 'Vlan798 10.4.4.4 66'), ('Vlan797', OrderedDict([('#standalone', True)])), ('10.2.2.2', OrderedDict([('#text', '22 tag 5555'), ('22', OrderedDict([('#text', 'tag 5555'), ('tag', OrderedDict([('#text', '5555'), ('5555', OrderedDict([('#standalone', True)]))]))]))])), ('10.3.3.3', OrderedDict([('#text', '44'), ('44', OrderedDict([('#standalone', True)]))])), ('Vlan798', OrderedDict([('#text', '10.4.4.4 66'), ('10.4.4.4', OrderedDict([('#text', '66'), ('66', OrderedDict([('#standalone', True)]))]))]))]))])), ('vrf', OrderedDict([('#text', 'mgmtVrf 5.5.5.5 255.255.255.255 FastEthernet1 192.168.5.5'), ('mgmtVrf', OrderedDict([('#text', '5.5.5.5 255.255.255.255 FastEthernet1 192.168.5.5'), ('5.5.5.5', OrderedDict([('#text', '255.255.255.255 FastEthernet1 192.168.5.5'), ('255.255.255.255', OrderedDict([('#text', 'FastEthernet1 192.168.5.5'), ('FastEthernet1', OrderedDict([('#text', '192.168.5.5'), ('192.168.5.5', OrderedDict([('#standalone', True)]))]))]))]))]))]))]))
('POST', 'static', '?prefix.?mask', [OrderedDict([('#text', 'Null0 tag 555'), ('Null0', OrderedDict([('#text', 'tag 555'), ('tag', OrderedDict([('#text', '555'), ('555', OrderedDict([('#standalone', True)]))]))])), ('mask', '255.255.255.255'), ('prefix', '1.1.1.1')]), OrderedDict([('#text', '10.1.1.1'), ('10.1.1.1', OrderedDict([('#standalone', True)])), ('mask', '255.255.255.255'), ('prefix', '2.2.2.2')]), OrderedDict([('#text', 'Vlan798 10.4.4.4 66'), ('Vlan797', OrderedDict([('#standalone', True)])), ('10.2.2.2', OrderedDict([('#text', '22 tag 5555'), ('22', OrderedDict([('#text', 'tag 5555'), ('tag', OrderedDict([('#text', '5555'), ('5555', OrderedDict([('#standalone', True)]))]))]))])), ('10.3.3.3', OrderedDict([('#text', '44'), ('44', OrderedDict([('#standalone', True)]))])), ('Vlan798', OrderedDict([('#text', '10.4.4.4 66'), ('10.4.4.4', OrderedDict([('#text', '66'), ('66', OrderedDict([('#standalone', True)]))]))])), ('mask', '255.255.255.0'), ('prefix', '3.3.3.0')]), OrderedDict([('#text', '5.5.5.5 255.255.255.255 FastEthernet1 192.168.5.5'), ('5.5.5.5', OrderedDict([('#text', '255.255.255.255 FastEthernet1 192.168.5.5'), ('255.255.255.255', OrderedDict([('#text', 'FastEthernet1 192.168.5.5'), ('FastEthernet1', OrderedDict([('#text', '192.168.5.5'), ('192.168.5.5', OrderedDict([('#standalone', True)]))]))]))])), ('mask', 'mgmtVrf'), ('prefix', 'vrf')])])
DEBUG:napalm-yang:Parsing element static[1.1.1.1/32]
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes/static[prefix='1.1.1.1/32']
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes/static[prefix='1.1.1.1/32']/prefix
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes/static[prefix='1.1.1.1/32']/prefix
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes/static[prefix='1.1.1.1/32']/next-hops
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes/static[prefix='1.1.1.1/32']/next-hops
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes/static[prefix='1.1.1.1/32']/next-hops/next-hop
DEBUG:napalm-yang:Parsing attribute: /network-instances/network-instance[name='global']/protocols/protocol[identifier='static' name='static']/static-routes/static[prefix='1.1.1.1/32']/next-hops/next-hop
('PRE ', 'next_hop', '?interface_ref.?next_hop_addr', OrderedDict([('#text', 'Null0 tag 555'), ('Null0', OrderedDict([('#text', 'tag 555'), ('tag', OrderedDict([('#text', '555'), ('555', OrderedDict([('#standalone', True)]))]))])), ('mask', '255.255.255.255'), ('prefix', '1.1.1.1')]))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
/home/matej/Projects/napalmyang/testmocked.py in <module>()
     46     running = napalm_yang.base.Root()
     47     running.add_model(model)
---> 48     running.parse_config(device=device)
     49 
     50 expected = load_json_model(base, profile, model, mode, case, "expected.json")

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/base.pyc in parse_config(self, device, profile, native, attrs)
    223         for v in attrs:
    224             parser = Parser(v, device=device, profile=profile, native=native, is_config=True)
--> 225             parser.parse()
    226 
    227     def parse_state(self, device=None, profile=None, native=None, attrs=None):

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in parse(self)
     83         if "parent" not in self.bookmarks:
     84             self.bookmarks["parent".format(self._yang_name)] = self.native
---> 85         self._parse(self._yang_name, self.model, self.mapping[self._yang_name])
     86 
     87     def _parse(self, attribute, model, mapping):

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     89 
     90         if model._is_container in ("container", ):
---> 91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
     93             self._parse_list(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_container(self, attribute, model, mapping)
    127                 parser.parse()
    128             else:
--> 129                 self._parse(k, v, mapping[v._yang_name])
    130 
    131         # Restoring state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
---> 93             self._parse_list(attribute, model, mapping)
     94         else:
     95             self._parse_leaf(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_list(self, attribute, model, mapping)
    169 
    170             element_mapping = copy.deepcopy(mapping)
--> 171             self._parse(key, obj, element_mapping)
    172 
    173         # Restore state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     89 
     90         if model._is_container in ("container", ):
---> 91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
     93             self._parse_list(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_container(self, attribute, model, mapping)
    127                 parser.parse()
    128             else:
--> 129                 self._parse(k, v, mapping[v._yang_name])
    130 
    131         # Restoring state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     89 
     90         if model._is_container in ("container", ):
---> 91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
     93             self._parse_list(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_container(self, attribute, model, mapping)
    127                 parser.parse()
    128             else:
--> 129                 self._parse(k, v, mapping[v._yang_name])
    130 
    131         # Restoring state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
---> 93             self._parse_list(attribute, model, mapping)
     94         else:
     95             self._parse_leaf(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_list(self, attribute, model, mapping)
    169 
    170             element_mapping = copy.deepcopy(mapping)
--> 171             self._parse(key, obj, element_mapping)
    172 
    173         # Restore state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     89 
     90         if model._is_container in ("container", ):
---> 91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
     93             self._parse_list(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_container(self, attribute, model, mapping)
    127                 parser.parse()
    128             else:
--> 129                 self._parse(k, v, mapping[v._yang_name])
    130 
    131         # Restoring state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     89 
     90         if model._is_container in ("container", ):
---> 91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
     93             self._parse_list(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_container(self, attribute, model, mapping)
    127                 parser.parse()
    128             else:
--> 129                 self._parse(k, v, mapping[v._yang_name])
    130 
    131         # Restoring state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
---> 93             self._parse_list(attribute, model, mapping)
     94         else:
     95             self._parse_leaf(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_list(self, attribute, model, mapping)
    169 
    170             element_mapping = copy.deepcopy(mapping)
--> 171             self._parse(key, obj, element_mapping)
    172 
    173         # Restore state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     89 
     90         if model._is_container in ("container", ):
---> 91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
     93             self._parse_list(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_container(self, attribute, model, mapping)
    127                 parser.parse()
    128             else:
--> 129                 self._parse(k, v, mapping[v._yang_name])
    130 
    131         # Restoring state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     89 
     90         if model._is_container in ("container", ):
---> 91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
     93             self._parse_list(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_container(self, attribute, model, mapping)
    127                 parser.parse()
    128             else:
--> 129                 self._parse(k, v, mapping[v._yang_name])
    130 
    131         # Restoring state

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse(self, attribute, model, mapping)
     91             self._parse_container(attribute, model, mapping)
     92         elif model._yang_type in ("list", ):
---> 93             self._parse_list(attribute, model, mapping)
     94         else:
     95             self._parse_leaf(attribute, model, mapping)

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parser.pyc in _parse_list(self, attribute, model, mapping)
    145 
    146         for key, block, extra_vars in self.parser.parse_list(attribute, mapping["_process"],
--> 147                                                              self.bookmarks):
    148             logger.debug("Parsing element {}[{}]".format(attribute, key))
    149 

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parsers/base.pyc in parse_list(self, attribute, mapping, bookmarks)
     90             data = self.resolve_path(bookmarks, m.get("from", "parent"))
     91 
---> 92             for key, block, extra_vars in self._parse_list_default(attribute, m, data):
     93                 yield key, block, extra_vars
     94 

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parsers/jsonp.py in _parse_list_default(self, attribute, mapping, data, key)
     73 
     74         print('PRE ', attribute, mapping.get("path", ""), data)
---> 75         d = self.resolve_path(data, mapping.get("path", ""), mapping.get("default"))
     76         print('POST', attribute, mapping.get("path", ""), d)
     77         regexp = mapping.get('regexp')

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parsers/base.pyc in resolve_path(self, my_dict, path, default, check_presence)
     43                     #    result.append((k, v))
     44                     #    continue
---> 45                     r = self.resolve_path(v, ".".join(path_split), default, check_presence)
     46                     if not r:
     47                         break

/home/matej/Projects/napalmyang/napalm-yang/napalm_yang/parsers/base.pyc in resolve_path(self, my_dict, path, default, check_presence)
     31                     if isinstance(b, dict):
     32                         b = [b]
---> 33                     p, var_name = p.split(":")
     34                     try:
     35                         iterator = {e[var_name]: e for e in b}.items()

ValueError: need more than 1 value to unpack
```

The touples `('mask', '255.255.255.255'), ('prefix', '1.1.1.1')` in the last PRE line are the problem.

This fix will just pass them through unchanged.

