### PR TITLE
Add type for fxp interfaces on Junos

### DIFF
--- a/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -42,6 +42,7 @@ interfaces:
                           vlan: ethernetCsmacd
                           lo: softwareLoopback
                           ae: ieee8023adLag
+                          fxp: ethernetCsmacd
             enabled:
                 _process:
                     - path: "disable"


### PR DESCRIPTION
Resolves https://github.com/napalm-automation/napalm-yang/issues/89.

The fxp interfaces are used for manamenet, so they probably fall
into the same category ethernetCsmacd, as ge, xe, etc.
Juniper description:
"Management and internal Ethernet interfaces. For M Series routers,
MX Series routers, T Series routers, and TX Series routers, you can
use the show chassis hardware command to display hardware information
about the router, including its Routing Engine model."