### PR TITLE
IOS-XE OpenConfig/RESTCONF mapping - oc-interfaces

### DIFF
--- a/napalm_yang/jinja_filters/__init__.py
+++ b/napalm_yang/jinja_filters/__init__.py
@@ -1,11 +1,13 @@
 import ip_filters
 import json_filters
 import vlan_filters
+import timestamp_filters
 
 JINJA_FILTERS = [
     ip_filters,
     json_filters,
     vlan_filters,
+    timestamp_filters,
 ]
 
 

--- a/napalm_yang/jinja_filters/timestamp_filters.py
+++ b/napalm_yang/jinja_filters/timestamp_filters.py
@@ -1,0 +1,23 @@
+from datetime import datetime, tzinfo, timedelta
+import dateutil.parser
+from napalm_yang.jinja_filters.helpers import check_empty
+
+class UTC(tzinfo):
+        def utcoffset(self, dt):
+            return timedelta(0)
+        def tzname(self, dt):
+            return "UTC"
+        def dst(self, dt):
+            return timedelta(0)
+
+EPOCH = datetime.utcfromtimestamp(0).replace(tzinfo=UTC())
+
+def filters():
+    return {
+        "iso8601_to_unix": iso8601_to_unix,
+    }
+
+# Converts an ios8601 formated string into a unix timestamp
+@check_empty()
+def iso8601_to_unix(string):
+    return (dateutil.parser.parse(string) - EPOCH).total_seconds()

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-if-ip/ipv4.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-if-ip/ipv4.yaml
@@ -1,0 +1,94 @@
+---
+metadata:
+    processor: JSONParser
+
+ipv4:
+    _process: not_implemented
+    addresses:
+        _process: not_implemented
+        address:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                prefix-length:
+                    _process: not_implemented
+            ip:
+                _process: not_implemented
+            state:
+                _process: not_implemented
+            vrrp:
+                _process: not_implemented
+                vrrp-group:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        accept-mode:
+                            _process: not_implemented
+                        advertisement-interval:
+                            _process: not_implemented
+                        preempt:
+                            _process: not_implemented
+                        preempt-delay:
+                            _process: not_implemented
+                        priority:
+                            _process: not_implemented
+                        virtual-address:
+                            _process: not_implemented
+                        virtual-router-id:
+                            _process: not_implemented
+                    interface-tracking:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            priority-decrement:
+                                _process: not_implemented
+                            track-interface:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+                    virtual-router-id:
+                        _process: not_implemented
+    config:
+        _process: not_implemented
+        enabled:
+            _process: not_implemented
+        mtu:
+            _process: not_implemented
+    neighbors:
+        _process: not_implemented
+        neighbor:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                link-layer-address:
+                    _process: not_implemented
+            ip:
+                _process: not_implemented
+            state:
+                _process: not_implemented
+    state:
+        _process: not_implemented
+    unnumbered:
+        _process: not_implemented
+        config:
+            _process: not_implemented
+            enabled:
+                _process: not_implemented
+        interface-ref:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                subinterface:
+                    _process: not_implemented
+            state:
+                _process: not_implemented
+        state:
+            _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-if-ip/ipv6.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-if-ip/ipv6.yaml
@@ -1,0 +1,98 @@
+---
+metadata:
+    processor: JSONParser
+
+ipv6:
+    _process: not_implemented
+    addresses:
+        _process: not_implemented
+        address:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                prefix-length:
+                    _process: not_implemented
+            ip:
+                _process: not_implemented
+            state:
+                _process: not_implemented
+            vrrp:
+                _process: not_implemented
+                vrrp-group:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        accept-mode:
+                            _process: not_implemented
+                        advertisement-interval:
+                            _process: not_implemented
+                        preempt:
+                            _process: not_implemented
+                        preempt-delay:
+                            _process: not_implemented
+                        priority:
+                            _process: not_implemented
+                        virtual-address:
+                            _process: not_implemented
+                        virtual-link-local:
+                            _process: not_implemented
+                        virtual-router-id:
+                            _process: not_implemented
+                    interface-tracking:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            priority-decrement:
+                                _process: not_implemented
+                            track-interface:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+                    virtual-router-id:
+                        _process: not_implemented
+    config:
+        _process: not_implemented
+        dup-addr-detect-transmits:
+            _process: not_implemented
+        enabled:
+            _process: not_implemented
+        mtu:
+            _process: not_implemented
+    neighbors:
+        _process: not_implemented
+        neighbor:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                link-layer-address:
+                    _process: not_implemented
+            ip:
+                _process: not_implemented
+            state:
+                _process: not_implemented
+    state:
+        _process: not_implemented
+    unnumbered:
+        _process: not_implemented
+        config:
+            _process: not_implemented
+            enabled:
+                _process: not_implemented
+        interface-ref:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                subinterface:
+                    _process: not_implemented
+            state:
+                _process: not_implemented
+        state:
+            _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -1,0 +1,69 @@
+---
+metadata:
+    processor: JSONParser
+    execute:
+        - method: _rpc
+          kwargs:
+            get: config/native/interface?deep
+
+interfaces:
+    _process: unnecessary
+    interface:
+        _process:
+            - from: root_interfaces.0
+              path: Cisco-IOS-XE-native:interface.?type
+              key: "{{ type }}{{ name }}"
+              regexp: ^(?P<value>(\w|-)*\d+(\/\d+)*)$
+        config:
+            _process: unnecessary
+            description:
+                _process:
+                    - from: parent
+                      path: description
+            enabled:
+                _process:
+                    - from: parent
+                      present: no
+                      path: shutdown
+            mtu:
+                _process: unnecessary
+            name:
+                _process: unnecessary
+            type:
+                _process: unnecessary
+        hold-time:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                down:
+                    _process: not_implemented
+                up:
+                    _process: not_implemented
+            state:
+                _process: not_implemented
+        name:
+            _process:
+                - from: interface
+                  path: '?name'
+                  key: "{{ name }}"
+                  regexp: ^(?P<value>(\w|-)*\d+(\/\d+)*)$
+        state:
+            _process: not_implemented
+        subinterfaces:
+            _process: not_implemented
+            subinterface:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    description:
+                        _process: not_implemented
+                    enabled:
+                        _process: not_implemented
+                    index:
+                        _process: not_implemented
+                    name:
+                        _process: not_implemented
+                index:
+                    _process: not_implemented
+                state:
+                    _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -4,33 +4,35 @@ metadata:
     execute:
         - method: _rpc
           kwargs:
-            get: config/native/interface?deep
+            get: data/openconfig-interfaces:interfaces
 
 interfaces:
-    _process: unnecessary
+    _process:
+      - from: root_interfaces.0
+        path: openconfig-interfaces:interfaces
     interface:
-        _process:
-            - from: root_interfaces.0
-              path: Cisco-IOS-XE-native:interface.?type
-              key: "{{ type }}{{ name }}"
-              regexp: ^(?P<value>(\w|-)*\d+(\/\d+)*)$
+        _process: 
+          - path: interface
+            key: name
         config:
-            _process: unnecessary
+            _process: 
+              - path: config
             description:
-                _process:
-                    - from: parent
-                      path: description
+                _process:  
+                  - path: description
             enabled:
-                _process:
-                    - from: parent
-                      present: no
-                      path: shutdown
+                _process:  
+                  - path: enabled
             mtu:
-                _process: unnecessary
+                _process:  
+                  - path: mtu
             name:
-                _process: unnecessary
+                _process:  
+                  - path: name
             type:
-                _process: unnecessary
+                _process:    
+                  - path: type
+                    regexp: ".*:(?P<value>[a-zA-Z]+)"
         hold-time:
             _process: not_implemented
             config:
@@ -40,30 +42,29 @@ interfaces:
                 up:
                     _process: not_implemented
             state:
-                _process: not_implemented
+                _process: unnecessary
         name:
-            _process:
-                - from: interface
-                  path: '?name'
-                  key: "{{ name }}"
-                  regexp: ^(?P<value>(\w|-)*\d+(\/\d+)*)$
-        state:
-            _process: not_implemented
+            _process: unnecessary
         subinterfaces:
-            _process: not_implemented
+            _process: 
+              - path: subinterfaces
             subinterface:
-                _process: not_implemented
+                _process: 
+                  - path: subinterface
+                    key: '{{ index }}'
                 config:
-                    _process: not_implemented
+                    _process: 
+                      - path: config
                     description:
-                        _process: not_implemented
+                        _process: 
+                          - path: description
                     enabled:
-                        _process: not_implemented
+                        _process:
+                          - path: enabled
                     index:
-                        _process: not_implemented
+                        _process: unnecessary
                     name:
-                        _process: not_implemented
+                        _process:
+                          - path: name
                 index:
-                    _process: not_implemented
-                state:
-                    _process: not_implemented
+                    _process: unnecessary

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -4,7 +4,7 @@ metadata:
     execute:
         - method: _rpc
           kwargs:
-            get: data/openconfig-interfaces:interfaces
+            get: /data/openconfig-interfaces:interfaces
 
 interfaces:
     _process:

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-network-instance/network-instances.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-network-instance/network-instances.yaml
@@ -1,0 +1,3010 @@
+---
+metadata:
+    processor: JSONParser
+    execute:
+        - method: _rpc
+          kwargs:
+            get: data/openconfig-network-instance:network-instances
+
+network-instances:
+    _process:
+      - from: root_network-instances.0
+        path: openconfig-network-instance:network-instances
+    network-instance:
+        _process: 
+          - path: network-instance
+            key: name
+        afts:
+            _process: not_implemented
+            aft:
+                _process: not_implemented
+                address-family:
+                    _process: not_implemented
+                config:
+                    _process: not_implemented
+                    address-family:
+                        _process: not_implemented
+                entries:
+                    _process: not_implemented
+                    entry:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            index:
+                                _process: not_implemented
+                        index:
+                            _process: not_implemented
+                        match:
+                            _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        next-hops:
+                            _process: not_implemented
+                            next-hop:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    index:
+                                        _process: not_implemented
+                                index:
+                                    _process: not_implemented
+                                interface-ref:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        interface:
+                                            _process: not_implemented
+                                        subinterface:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        state:
+                            _process: not_implemented
+                state:
+                    _process: not_implemented
+        config:
+            _process: 
+              - path: config
+            description:
+                _process:  
+                  - path: description
+            enabled:
+                _process:  
+                  - path: enabled
+            enabled-address-families:
+                _process:  
+                  - path: enabled-address-families
+            mtu:
+                _process:  
+                  - path: mtu
+            name:
+                _process:  
+                  - path: name
+            route-distinguisher:
+                _process:  
+                  - path: route-distinguisher
+            router-id:
+                _process:  
+                  - path: router-id
+            type:
+                _process:  
+                  - path: type
+                    regexp: ".*:(?P<value>.*)"
+        connection-points:
+            _process: not_implemented
+            connection-point:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    connection-point-id:
+                        _process: not_implemented
+                connection-point-id:
+                    _process: not_implemented
+                endpoints:
+                    _process: not_implemented
+                    endpoint:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            endpoint-id:
+                                _process: not_implemented
+                            precedence:
+                                _process: not_implemented
+                            type:
+                                _process: not_implemented
+                        endpoint-id:
+                            _process: not_implemented
+                        local:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                subinterface:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        remote:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                remote-system:
+                                    _process: not_implemented
+                                virtual-circuit-identifier:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                state:
+                    _process: not_implemented
+        encapsulation:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                control-word:
+                    _process: not_implemented
+                encapsulation-type:
+                    _process: not_implemented
+                label-allocation-mode:
+                    _process: not_implemented
+            state:
+                _process: not_implemented
+        fdb:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                mac-aging-time:
+                    _process: not_implemented
+                mac-learning:
+                    _process: not_implemented
+                maximum-entries:
+                    _process: not_implemented
+            mac-table:
+                _process: not_implemented
+                entries:
+                    _process: not_implemented
+                    entry:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            mac-address:
+                                _process: not_implemented
+                            vlan:
+                                _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        mac-address:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+            state:
+                _process: not_implemented
+        inter-instance-policies:
+            _process: not_implemented
+            apply-policy:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    default-export-policy:
+                        _process: not_implemented
+                    default-import-policy:
+                        _process: not_implemented
+                    export-policy:
+                        _process: not_implemented
+                    import-policy:
+                        _process: not_implemented
+                state:
+                    _process: not_implemented
+        interfaces:
+            _process: not_implemented
+            interface:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    associated-address-families:
+                        _process: not_implemented
+                    id:
+                        _process: not_implemented
+                    interface:
+                        _process: not_implemented
+                    subinterface:
+                        _process: not_implemented
+                id:
+                    _process: not_implemented
+                state:
+                    _process: not_implemented
+        mpls:
+            _process: not_implemented
+            global:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    null-label:
+                        _process: not_implemented
+                interface-attributes:
+                    _process: not_implemented
+                    interface:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            interface-id:
+                                _process: not_implemented
+                            mpls-enabled:
+                                _process: not_implemented
+                        interface-id:
+                            _process: not_implemented
+                        interface-ref:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                subinterface:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                reserved-label-blocks:
+                    _process: not_implemented
+                    reserved-label-block:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            local-id:
+                                _process: not_implemented
+                            lower-bound:
+                                _process: not_implemented
+                            upper-bound:
+                                _process: not_implemented
+                        local-id:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+                state:
+                    _process: not_implemented
+            lsps:
+                _process: not_implemented
+                constrained-path:
+                    _process: not_implemented
+                    named-explicit-paths:
+                        _process: not_implemented
+                        named-explicit-path:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                name:
+                                    _process: not_implemented
+                                sid-protection-required:
+                                    _process: not_implemented
+                                sid-selection-mode:
+                                    _process: not_implemented
+                            explicit-route-objects:
+                                _process: not_implemented
+                                explicit-route-object:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        address:
+                                            _process: not_implemented
+                                        hop-type:
+                                            _process: not_implemented
+                                        index:
+                                            _process: not_implemented
+                                    index:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                            name:
+                                _process: not_implemented
+                            state:
+                                _process: not_implemented
+                    tunnels:
+                        _process: not_implemented
+                        tunnel:
+                            _process: not_implemented
+                            bandwidth:
+                                _process: not_implemented
+                                auto-bandwidth:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        adjust-interval:
+                                            _process: not_implemented
+                                        adjust-threshold:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        max-bw:
+                                            _process: not_implemented
+                                        min-bw:
+                                            _process: not_implemented
+                                    overflow:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                            overflow-threshold:
+                                                _process: not_implemented
+                                            trigger-event-count:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    underflow:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                            trigger-event-count:
+                                                _process: not_implemented
+                                            underflow-threshold:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    set-bandwidth:
+                                        _process: not_implemented
+                                    specification-type:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                admin-status:
+                                    _process: not_implemented
+                                description:
+                                    _process: not_implemented
+                                hold-priority:
+                                    _process: not_implemented
+                                metric:
+                                    _process: not_implemented
+                                metric-type:
+                                    _process: not_implemented
+                                name:
+                                    _process: not_implemented
+                                preference:
+                                    _process: not_implemented
+                                protection-style-requested:
+                                    _process: not_implemented
+                                reoptimize-timer:
+                                    _process: not_implemented
+                                setup-priority:
+                                    _process: not_implemented
+                                shortcut-eligible:
+                                    _process: not_implemented
+                                signaling-protocol:
+                                    _process: not_implemented
+                                soft-preemption:
+                                    _process: not_implemented
+                                source:
+                                    _process: not_implemented
+                                type:
+                                    _process: not_implemented
+                            name:
+                                _process: not_implemented
+                            p2p-tunnel-attributes:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    destination:
+                                        _process: not_implemented
+                                p2p-primary-path:
+                                    _process: not_implemented
+                                    p2p-primary-path:
+                                        _process: not_implemented
+                                        admin-groups:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                exclude-group:
+                                                    _process: not_implemented
+                                                include-all-group:
+                                                    _process: not_implemented
+                                                include-any-group:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        candidate-secondary-paths:
+                                            _process: not_implemented
+                                            candidate-secondary-path:
+                                                _process: not_implemented
+                                                config:
+                                                    _process: not_implemented
+                                                    priority:
+                                                        _process: not_implemented
+                                                    secondary-path:
+                                                        _process: not_implemented
+                                                secondary-path:
+                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            cspf-tiebreaker:
+                                                _process: not_implemented
+                                            explicit-path-name:
+                                                _process: not_implemented
+                                            hold-priority:
+                                                _process: not_implemented
+                                            name:
+                                                _process: not_implemented
+                                            path-computation-method:
+                                                _process: not_implemented
+                                            path-computation-server:
+                                                _process: not_implemented
+                                            preference:
+                                                _process: not_implemented
+                                            retry-timer:
+                                                _process: not_implemented
+                                            setup-priority:
+                                                _process: not_implemented
+                                            use-cspf:
+                                                _process: not_implemented
+                                        name:
+                                            _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                p2p-secondary-paths:
+                                    _process: not_implemented
+                                    p2p-secondary-path:
+                                        _process: not_implemented
+                                        admin-groups:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                exclude-group:
+                                                    _process: not_implemented
+                                                include-all-group:
+                                                    _process: not_implemented
+                                                include-any-group:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            cspf-tiebreaker:
+                                                _process: not_implemented
+                                            explicit-path-name:
+                                                _process: not_implemented
+                                            hold-priority:
+                                                _process: not_implemented
+                                            name:
+                                                _process: not_implemented
+                                            path-computation-method:
+                                                _process: not_implemented
+                                            path-computation-server:
+                                                _process: not_implemented
+                                            preference:
+                                                _process: not_implemented
+                                            retry-timer:
+                                                _process: not_implemented
+                                            setup-priority:
+                                                _process: not_implemented
+                                            use-cspf:
+                                                _process: not_implemented
+                                        name:
+                                            _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                static-lsps:
+                    _process: not_implemented
+                    static-lsp:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            name:
+                                _process: not_implemented
+                        egress:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                incoming-label:
+                                    _process: not_implemented
+                                next-hop:
+                                    _process: not_implemented
+                                push-label:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        ingress:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                incoming-label:
+                                    _process: not_implemented
+                                next-hop:
+                                    _process: not_implemented
+                                push-label:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        name:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        transit:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                incoming-label:
+                                    _process: not_implemented
+                                next-hop:
+                                    _process: not_implemented
+                                push-label:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                unconstrained-path:
+                    _process: not_implemented
+                    path-setup-protocol:
+                        _process: not_implemented
+            signaling-protocols:
+                _process: not_implemented
+                rsvp-te:
+                    _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enable:
+                                    _process: not_implemented
+                                recovery-time:
+                                    _process: not_implemented
+                                restart-time:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        hellos:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                hello-interval:
+                                    _process: not_implemented
+                                refresh-reduction:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        soft-preemption:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enable:
+                                    _process: not_implemented
+                                soft-preemption-timeout:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    interface-attributes:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            authentication:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    authentication-key:
+                                        _process: not_implemented
+                                    enable:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            bandwidth-reservations:
+                                _process: not_implemented
+                                bandwidth-reservation:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                interface-id:
+                                    _process: not_implemented
+                            hellos:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    hello-interval:
+                                        _process: not_implemented
+                                    refresh-reduction:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            interface-id:
+                                _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            protection:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    bypass-optimize-interval:
+                                        _process: not_implemented
+                                    link-protection-style-requested:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            subscription:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    subscription:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                    neighbors:
+                        _process: not_implemented
+                        neighbor:
+                            _process: not_implemented
+                    sessions:
+                        _process: not_implemented
+                        session:
+                            _process: not_implemented
+                segment-routing:
+                    _process: not_implemented
+                    aggregate-sid-counters:
+                        _process: not_implemented
+                        aggregate-sid-counter:
+                            _process: not_implemented
+                    interfaces:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                interface-id:
+                                    _process: not_implemented
+                            interface-id:
+                                _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            sid-counters:
+                                _process: not_implemented
+                                sid-counter:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+            te-global-attributes:
+                _process: not_implemented
+                mpls-admin-groups:
+                    _process: not_implemented
+                    admin-group:
+                        _process: not_implemented
+                        admin-group-name:
+                            _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            admin-group-name:
+                                _process: not_implemented
+                            bit-position:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                srlgs:
+                    _process: not_implemented
+                    srlg:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            cost:
+                                _process: not_implemented
+                            flooding-type:
+                                _process: not_implemented
+                            name:
+                                _process: not_implemented
+                            value:
+                                _process: not_implemented
+                        name:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        static-srlg-members:
+                            _process: not_implemented
+                            members-list:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    from-address:
+                                        _process: not_implemented
+                                    to-address:
+                                        _process: not_implemented
+                                from-address:
+                                    _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                te-lsp-timers:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        cleanup-delay:
+                            _process: not_implemented
+                        install-delay:
+                            _process: not_implemented
+                        reoptimize-timer:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+            te-interface-attributes:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        admin-group:
+                            _process: not_implemented
+                        interface-id:
+                            _process: not_implemented
+                        srlg-membership:
+                            _process: not_implemented
+                        te-metric:
+                            _process: not_implemented
+                    igp-flooding-bandwidth:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            delta-percentage:
+                                _process: not_implemented
+                            down-thresholds:
+                                _process: not_implemented
+                            threshold-specification:
+                                _process: not_implemented
+                            threshold-type:
+                                _process: not_implemented
+                            up-down-thresholds:
+                                _process: not_implemented
+                            up-thresholds:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    interface-id:
+                        _process: not_implemented
+                    interface-ref:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            interface:
+                                _process: not_implemented
+                            subinterface:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+        name:
+            _process: unnecessary
+        policy-forwarding:
+            _process: not_implemented
+            interfaces:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        apply-forwarding-policy:
+                            _process: not_implemented
+                        interface-id:
+                            _process: not_implemented
+                    interface-id:
+                        _process: not_implemented
+                    interface-ref:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            interface:
+                                _process: not_implemented
+                            subinterface:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+            path-selection-groups:
+                _process: not_implemented
+                path-selection-group:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        group-id:
+                            _process: not_implemented
+                        mpls-lsp:
+                            _process: not_implemented
+                    group-id:
+                        _process: not_implemented
+                    state:
+                        _process: not_implemented
+            policies:
+                _process: not_implemented
+                policy:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        policy-id:
+                            _process: not_implemented
+                    policy-id:
+                        _process: not_implemented
+                    rules:
+                        _process: not_implemented
+                        rule:
+                            _process: not_implemented
+                            action:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    decapsulate-gre:
+                                        _process: not_implemented
+                                    discard:
+                                        _process: not_implemented
+                                    network-instance:
+                                        _process: not_implemented
+                                    next-hop:
+                                        _process: not_implemented
+                                    path-selection-group:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                sequence-id:
+                                    _process: not_implemented
+                            ip:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    destination-ip-address:
+                                        _process: not_implemented
+                                    destination-ip-flow-label:
+                                        _process: not_implemented
+                                    dscp:
+                                        _process: not_implemented
+                                    hop-limit:
+                                        _process: not_implemented
+                                    ip-version:
+                                        _process: not_implemented
+                                    protocol:
+                                        _process: not_implemented
+                                    source-ip-address:
+                                        _process: not_implemented
+                                    source-ip-flow-label:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            l2:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    destination-mac:
+                                        _process: not_implemented
+                                    destination-mac-mask:
+                                        _process: not_implemented
+                                    ethertype:
+                                        _process: not_implemented
+                                    source-mac:
+                                        _process: not_implemented
+                                    source-mac-mask:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            sequence-id:
+                                _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            transport:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    destination-port:
+                                        _process: not_implemented
+                                    source-port:
+                                        _process: not_implemented
+                                    tcp-flags:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                    state:
+                        _process: not_implemented
+        protocols:
+            _process: not_implemented
+            protocol:
+                _process: not_implemented
+                bgp:
+                    _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        afi-safis:
+                            _process: not_implemented
+                            afi-safi:
+                                _process: not_implemented
+                                afi-safi-name:
+                                    _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    afi-safi-name:
+                                        _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                graceful-restart:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                ipv4-labeled-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                ipv4-unicast:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        send-default-route:
+                                            _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                ipv6-labeled-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                ipv6-unicast:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        send-default-route:
+                                            _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                l2vpn-evpn:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l2vpn-vpls:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l3vpn-ipv4-multicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l3vpn-ipv4-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l3vpn-ipv6-multicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l3vpn-ipv6-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                route-selection-options:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        advertise-inactive-routes:
+                                            _process: not_implemented
+                                        always-compare-med:
+                                            _process: not_implemented
+                                        enable-aigp:
+                                            _process: not_implemented
+                                        external-compare-router-id:
+                                            _process: not_implemented
+                                        ignore-as-path-length:
+                                            _process: not_implemented
+                                        ignore-next-hop-igp-metric:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                use-multiple-paths:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                    ebgp:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            allow-multiple-as:
+                                                _process: not_implemented
+                                            maximum-paths:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ibgp:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            maximum-paths:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                        confederation:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                identifier:
+                                    _process: not_implemented
+                                member-as:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            as:
+                                _process: not_implemented
+                            router-id:
+                                _process: not_implemented
+                        default-route-distance:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                external-route-distance:
+                                    _process: not_implemented
+                                internal-route-distance:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        dynamic-neighbor-prefixes:
+                            _process: not_implemented
+                            dynamic-neighbor-prefix:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    peer-group:
+                                        _process: not_implemented
+                                    prefix:
+                                        _process: not_implemented
+                                prefix:
+                                    _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                helper-only:
+                                    _process: not_implemented
+                                restart-time:
+                                    _process: not_implemented
+                                stale-routes-time:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        route-selection-options:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                advertise-inactive-routes:
+                                    _process: not_implemented
+                                always-compare-med:
+                                    _process: not_implemented
+                                enable-aigp:
+                                    _process: not_implemented
+                                external-compare-router-id:
+                                    _process: not_implemented
+                                ignore-as-path-length:
+                                    _process: not_implemented
+                                ignore-next-hop-igp-metric:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        use-multiple-paths:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                            ebgp:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    allow-multiple-as:
+                                        _process: not_implemented
+                                    maximum-paths:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            ibgp:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    maximum-paths:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                    neighbors:
+                        _process: not_implemented
+                        neighbor:
+                            _process: not_implemented
+                            add-paths:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    eligible-prefix-policy:
+                                        _process: not_implemented
+                                    receive:
+                                        _process: not_implemented
+                                    send-max:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            afi-safis:
+                                _process: not_implemented
+                                afi-safi:
+                                    _process: not_implemented
+                                    afi-safi-name:
+                                        _process: not_implemented
+                                    apply-policy:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            default-export-policy:
+                                                _process: not_implemented
+                                            default-import-policy:
+                                                _process: not_implemented
+                                            export-policy:
+                                                _process: not_implemented
+                                            import-policy:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        afi-safi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                    graceful-restart:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ipv4-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    ipv4-unicast:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ipv6-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    ipv6-unicast:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    l2vpn-evpn:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l2vpn-vpls:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv4-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv4-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv6-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv6-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    use-multiple-paths:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                        ebgp:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                allow-multiple-as:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                            apply-policy:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-export-policy:
+                                        _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    export-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            as-path-options:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    allow-own-as:
+                                        _process: not_implemented
+                                    replace-peer-as:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                auth-password:
+                                    _process: not_implemented
+                                description:
+                                    _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                local-as:
+                                    _process: not_implemented
+                                neighbor-address:
+                                    _process: not_implemented
+                                peer-as:
+                                    _process: not_implemented
+                                peer-group:
+                                    _process: not_implemented
+                                peer-type:
+                                    _process: not_implemented
+                                remove-private-as:
+                                    _process: not_implemented
+                                route-flap-damping:
+                                    _process: not_implemented
+                                send-community:
+                                    _process: not_implemented
+                            ebgp-multihop:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    multihop-ttl:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            error-handling:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    treat-as-withdraw:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            graceful-restart:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    helper-only:
+                                        _process: not_implemented
+                                    restart-time:
+                                        _process: not_implemented
+                                    stale-routes-time:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            logging-options:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    log-neighbor-state-changes:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            neighbor-address:
+                                _process: not_implemented
+                            route-reflector:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    route-reflector-client:
+                                        _process: not_implemented
+                                    route-reflector-cluster-id:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            timers:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    connect-retry:
+                                        _process: not_implemented
+                                    hold-time:
+                                        _process: not_implemented
+                                    keepalive-interval:
+                                        _process: not_implemented
+                                    minimum-advertisement-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            transport:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    local-address:
+                                        _process: not_implemented
+                                    mtu-discovery:
+                                        _process: not_implemented
+                                    passive-mode:
+                                        _process: not_implemented
+                                    tcp-mss:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            use-multiple-paths:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                ebgp:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        allow-multiple-as:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                    peer-groups:
+                        _process: not_implemented
+                        peer-group:
+                            _process: not_implemented
+                            add-paths:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    eligible-prefix-policy:
+                                        _process: not_implemented
+                                    receive:
+                                        _process: not_implemented
+                                    send-max:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            afi-safis:
+                                _process: not_implemented
+                                afi-safi:
+                                    _process: not_implemented
+                                    afi-safi-name:
+                                        _process: not_implemented
+                                    apply-policy:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            default-export-policy:
+                                                _process: not_implemented
+                                            default-import-policy:
+                                                _process: not_implemented
+                                            export-policy:
+                                                _process: not_implemented
+                                            import-policy:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        afi-safi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                    graceful-restart:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ipv4-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    ipv4-unicast:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ipv6-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    ipv6-unicast:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    l2vpn-evpn:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l2vpn-vpls:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv4-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv4-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv6-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv6-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    route-selection-options:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            advertise-inactive-routes:
+                                                _process: not_implemented
+                                            always-compare-med:
+                                                _process: not_implemented
+                                            enable-aigp:
+                                                _process: not_implemented
+                                            external-compare-router-id:
+                                                _process: not_implemented
+                                            ignore-as-path-length:
+                                                _process: not_implemented
+                                            ignore-next-hop-igp-metric:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    use-multiple-paths:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                        ebgp:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                allow-multiple-as:
+                                                    _process: not_implemented
+                                                maximum-paths:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        ibgp:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                maximum-paths:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                            apply-policy:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-export-policy:
+                                        _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    export-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            as-path-options:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    allow-own-as:
+                                        _process: not_implemented
+                                    replace-peer-as:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                auth-password:
+                                    _process: not_implemented
+                                description:
+                                    _process: not_implemented
+                                local-as:
+                                    _process: not_implemented
+                                peer-as:
+                                    _process: not_implemented
+                                peer-group-name:
+                                    _process: not_implemented
+                                peer-type:
+                                    _process: not_implemented
+                                remove-private-as:
+                                    _process: not_implemented
+                                route-flap-damping:
+                                    _process: not_implemented
+                                send-community:
+                                    _process: not_implemented
+                            ebgp-multihop:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    multihop-ttl:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            error-handling:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    treat-as-withdraw:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            graceful-restart:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    helper-only:
+                                        _process: not_implemented
+                                    restart-time:
+                                        _process: not_implemented
+                                    stale-routes-time:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            logging-options:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    log-neighbor-state-changes:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            peer-group-name:
+                                _process: not_implemented
+                            route-reflector:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    route-reflector-client:
+                                        _process: not_implemented
+                                    route-reflector-cluster-id:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            timers:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    connect-retry:
+                                        _process: not_implemented
+                                    hold-time:
+                                        _process: not_implemented
+                                    keepalive-interval:
+                                        _process: not_implemented
+                                    minimum-advertisement-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            transport:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    local-address:
+                                        _process: not_implemented
+                                    mtu-discovery:
+                                        _process: not_implemented
+                                    passive-mode:
+                                        _process: not_implemented
+                                    tcp-mss:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            use-multiple-paths:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                ebgp:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        allow-multiple-as:
+                                            _process: not_implemented
+                                        maximum-paths:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                ibgp:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        maximum-paths:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                config:
+                    _process: not_implemented
+                    default-metric:
+                        _process: not_implemented
+                    enabled:
+                        _process: not_implemented
+                    identifier:
+                        _process: not_implemented
+                    name:
+                        _process: not_implemented
+                identifier:
+                    _process: not_implemented
+                isis:
+                    _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        afi-safi:
+                            _process: not_implemented
+                            af:
+                                _process: not_implemented
+                                afi-name:
+                                    _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    afi-name:
+                                        _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    metric:
+                                        _process: not_implemented
+                                    safi-name:
+                                        _process: not_implemented
+                                multi-topology:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        afi-name:
+                                            _process: not_implemented
+                                        safi-name:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                safi-name:
+                                    _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            authentication-check:
+                                _process: not_implemented
+                            fast-flooding:
+                                _process: not_implemented
+                            iid-tlv:
+                                _process: not_implemented
+                            instance:
+                                _process: not_implemented
+                            level-capability:
+                                _process: not_implemented
+                            max-ecmp-paths:
+                                _process: not_implemented
+                            maximum-area-addresses:
+                                _process: not_implemented
+                            net:
+                                _process: not_implemented
+                            poi-tlv:
+                                _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                helper-only:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        igp-shortcuts:
+                            _process: not_implemented
+                            afi:
+                                _process: not_implemented
+                                afi-name:
+                                    _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    afi-name:
+                                        _process: not_implemented
+                                    nh-type:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        inter-level-propagation-policies:
+                            _process: not_implemented
+                            level1-to-level2:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            level2-to-level1:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        lsp-bit:
+                            _process: not_implemented
+                            attached-bit:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    ignore-bit:
+                                        _process: not_implemented
+                                    suppress-bit:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            overload-bit:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    advertise-high-metric:
+                                        _process: not_implemented
+                                    set-bit:
+                                        _process: not_implemented
+                                    set-bit-on-boot:
+                                        _process: not_implemented
+                                reset-triggers:
+                                    _process: not_implemented
+                                    reset-trigger:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            delay:
+                                                _process: not_implemented
+                                            reset-trigger:
+                                                _process: not_implemented
+                                        reset-trigger:
+                                            _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        mpls:
+                            _process: not_implemented
+                            igp-ldp-sync:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    post-session-up-delay:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        nsr:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        reference-bandwidth:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                reference-bandwidth:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        segment-routing:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                srgb:
+                                    _process: not_implemented
+                                srlb:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        timers:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                lsp-lifetime-interval:
+                                    _process: not_implemented
+                                lsp-refresh-interval:
+                                    _process: not_implemented
+                            lsp-generation:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    lsp-first-wait-interval:
+                                        _process: not_implemented
+                                    lsp-max-wait-interval:
+                                        _process: not_implemented
+                                    lsp-second-wait-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            spf:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    spf-first-interval:
+                                        _process: not_implemented
+                                    spf-hold-interval:
+                                        _process: not_implemented
+                                    spf-second-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        transport:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                lsp-mtu-size:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                    interfaces:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            afi-safi:
+                                _process: not_implemented
+                                af:
+                                    _process: not_implemented
+                                    afi-name:
+                                        _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        afi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        safi-name:
+                                            _process: not_implemented
+                                    safi-name:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                            authentication:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    hello-authentication:
+                                        _process: not_implemented
+                                key:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        auth-password:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            bfd:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    bfd-tlv:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            circuit-counters:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                circuit-type:
+                                    _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                hello-padding:
+                                    _process: not_implemented
+                                interface-id:
+                                    _process: not_implemented
+                                passive:
+                                    _process: not_implemented
+                            interface-id:
+                                _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            levels:
+                                _process: not_implemented
+                                level:
+                                    _process: not_implemented
+                                    adjacencies:
+                                        _process: not_implemented
+                                    afi-safi:
+                                        _process: not_implemented
+                                        af:
+                                            _process: not_implemented
+                                            afi-name:
+                                                _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                afi-name:
+                                                    _process: not_implemented
+                                                enabled:
+                                                    _process: not_implemented
+                                                metric:
+                                                    _process: not_implemented
+                                                safi-name:
+                                                    _process: not_implemented
+                                            safi-name:
+                                                _process: not_implemented
+                                            segment-routing:
+                                                _process: not_implemented
+                                                adjacency-sids:
+                                                    _process: not_implemented
+                                                    adjacency-sid:
+                                                        _process: not_implemented
+                                                        config:
+                                                            _process: not_implemented
+                                                            group:
+                                                                _process: not_implemented
+                                                            neighbor:
+                                                                _process: not_implemented
+                                                            protection-eligible:
+                                                                _process: not_implemented
+                                                            sid-id:
+                                                                _process: not_implemented
+                                                        neighbor:
+                                                            _process: not_implemented
+                                                        sid-id:
+                                                            _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                prefix-sids:
+                                                    _process: not_implemented
+                                                    prefix-sid:
+                                                        _process: not_implemented
+                                                        config:
+                                                            _process: not_implemented
+                                                            label-options:
+                                                                _process: not_implemented
+                                                            prefix:
+                                                                _process: not_implemented
+                                                            sid-id:
+                                                                _process: not_implemented
+                                                        prefix:
+                                                            _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        level-number:
+                                            _process: not_implemented
+                                        passive:
+                                            _process: not_implemented
+                                        priority:
+                                            _process: not_implemented
+                                    hello-authentication:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            hello-authentication:
+                                                _process: not_implemented
+                                        key:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                auth-password:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    level-number:
+                                        _process: not_implemented
+                                    packet-counters:
+                                        _process: not_implemented
+                                        cnsp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        esh:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        iih:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        ish:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        lsp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        psnp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        unknown:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    timers:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            hello-interval:
+                                                _process: not_implemented
+                                            hello-multiplier:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            timers:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    csnp-interval:
+                                        _process: not_implemented
+                                    lsp-pacing-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                    levels:
+                        _process: not_implemented
+                        level:
+                            _process: not_implemented
+                            authentication:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    csnp-authentication:
+                                        _process: not_implemented
+                                    lsp-authentication:
+                                        _process: not_implemented
+                                    psnp-authentication:
+                                        _process: not_implemented
+                                key:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        auth-password:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                authentication-check:
+                                    _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                level-number:
+                                    _process: not_implemented
+                                metric-style:
+                                    _process: not_implemented
+                            level-number:
+                                _process: not_implemented
+                            link-state-database:
+                                _process: not_implemented
+                            route-preference:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    external-route-preference:
+                                        _process: not_implemented
+                                    internal-route-preference:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            system-level-counters:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            traffic-engineering:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    ipv4-router-id:
+                                        _process: not_implemented
+                                    ipv6-router-id:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                local-aggregates:
+                    _process: not_implemented
+                    aggregate:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            discard:
+                                _process: not_implemented
+                            prefix:
+                                _process: not_implemented
+                            set-tag:
+                                _process: not_implemented
+                        prefix:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+                name:
+                    _process: not_implemented
+                ospfv2:
+                    _process: not_implemented
+                    areas:
+                        _process: not_implemented
+                        area:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                identifier:
+                                    _process: not_implemented
+                            identifier:
+                                _process: not_implemented
+                            interfaces:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        authentication-type:
+                                            _process: not_implemented
+                                        hide-network:
+                                            _process: not_implemented
+                                        id:
+                                            _process: not_implemented
+                                        metric:
+                                            _process: not_implemented
+                                        multi-area-adjacency-primary:
+                                            _process: not_implemented
+                                        network-type:
+                                            _process: not_implemented
+                                        passive:
+                                            _process: not_implemented
+                                        priority:
+                                            _process: not_implemented
+                                    id:
+                                        _process: not_implemented
+                                    interface-ref:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            interface:
+                                                _process: not_implemented
+                                            subinterface:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    lsa-filter:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            all:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    mpls:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            traffic-engineering-metric:
+                                                _process: not_implemented
+                                        igp-ldp-sync:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                enabled:
+                                                    _process: not_implemented
+                                                post-session-up-delay:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    neighbors:
+                                        _process: not_implemented
+                                        neighbor:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                metric:
+                                                    _process: not_implemented
+                                                router-id:
+                                                    _process: not_implemented
+                                            router-id:
+                                                _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    timers:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            dead-interval:
+                                                _process: not_implemented
+                                            hello-interval:
+                                                _process: not_implemented
+                                            retransmission-interval:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                            lsdb:
+                                _process: not_implemented
+                            mpls:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    traffic-engineering-enabled:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            virtual-links:
+                                _process: not_implemented
+                                virtual-link:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        remote-router-id:
+                                            _process: not_implemented
+                                    remote-router-id:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            hide-transit-only-networks:
+                                _process: not_implemented
+                            igp-shortcuts:
+                                _process: not_implemented
+                            log-adjacency-changes:
+                                _process: not_implemented
+                            router-id:
+                                _process: not_implemented
+                            summary-route-cost-mode:
+                                _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                helper-only:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        inter-area-propagation-policies:
+                            _process: not_implemented
+                            inter-area-propagation-policy:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    dst-area:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                    src-area:
+                                        _process: not_implemented
+                                dst-area:
+                                    _process: not_implemented
+                                src-area:
+                                    _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        mpls:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                traffic-engineering-extensions:
+                                    _process: not_implemented
+                            igp-ldp-sync:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    post-session-up-delay:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        timers:
+                            _process: not_implemented
+                            lsa-generation:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    initial-delay:
+                                        _process: not_implemented
+                                    maximum-delay:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            max-metric:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    include:
+                                        _process: not_implemented
+                                    set:
+                                        _process: not_implemented
+                                    timeout:
+                                        _process: not_implemented
+                                    trigger:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            spf:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    initial-delay:
+                                        _process: not_implemented
+                                    maximum-delay:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                state:
+                    _process: not_implemented
+                static-routes:
+                    _process: not_implemented
+                    static:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            prefix:
+                                _process: not_implemented
+                            set-tag:
+                                _process: not_implemented
+                        next-hops:
+                            _process: not_implemented
+                            next-hop:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    index:
+                                        _process: not_implemented
+                                    metric:
+                                        _process: not_implemented
+                                    next-hop:
+                                        _process: not_implemented
+                                    recurse:
+                                        _process: not_implemented
+                                index:
+                                    _process: not_implemented
+                                interface-ref:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        interface:
+                                            _process: not_implemented
+                                        subinterface:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        prefix:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+        segment-routing:
+            _process: not_implemented
+            srgbs:
+                _process: not_implemented
+                srgb:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        dataplane-type:
+                            _process: not_implemented
+                        ipv6-prefixes:
+                            _process: not_implemented
+                        local-id:
+                            _process: not_implemented
+                        mpls-label-blocks:
+                            _process: not_implemented
+                    local-id:
+                        _process: not_implemented
+                    state:
+                        _process: not_implemented
+            srlbs:
+                _process: not_implemented
+                srlb:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        dataplane-type:
+                            _process: not_implemented
+                        ipv6-prefix:
+                            _process: not_implemented
+                        local-id:
+                            _process: not_implemented
+                        mpls-label-block:
+                            _process: not_implemented
+                    local-id:
+                        _process: not_implemented
+                    state:
+                        _process: not_implemented
+        state:
+            _process: not_implemented
+        table-connections:
+            _process: not_implemented
+            table-connection:
+                _process: not_implemented
+                address-family:
+                    _process: not_implemented
+                config:
+                    _process: not_implemented
+                    address-family:
+                        _process: not_implemented
+                    default-import-policy:
+                        _process: not_implemented
+                    dst-protocol:
+                        _process: not_implemented
+                    import-policy:
+                        _process: not_implemented
+                    src-protocol:
+                        _process: not_implemented
+                dst-protocol:
+                    _process: not_implemented
+                src-protocol:
+                    _process: not_implemented
+                state:
+                    _process: not_implemented
+        tables:
+            _process: not_implemented
+            table:
+                _process: not_implemented
+                address-family:
+                    _process: not_implemented
+                config:
+                    _process: not_implemented
+                    address-family:
+                        _process: not_implemented
+                    protocol:
+                        _process: not_implemented
+                protocol:
+                    _process: not_implemented
+                state:
+                    _process: not_implemented
+        vlans:
+            _process: not_implemented
+            vlan:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    name:
+                        _process: not_implemented
+                    status:
+                        _process: not_implemented
+                    tpid:
+                        _process: not_implemented
+                    vlan-id:
+                        _process: not_implemented
+                members:
+                    _process: not_implemented
+                    member:
+                        _process: not_implemented
+                state:
+                    _process: not_implemented
+                vlan-id:
+                    _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-vlan/routed-vlan.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-vlan/routed-vlan.yaml
@@ -1,0 +1,12 @@
+---
+metadata:
+    processor: JSONParser
+
+routed-vlan:
+    _process: not_implemented
+    config:
+        _process: not_implemented
+        vlan:
+            _process: not_implemented
+    state:
+        _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-vlan/switched-vlan.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-vlan/switched-vlan.yaml
@@ -1,0 +1,18 @@
+---
+metadata:
+    processor: unset
+
+switched-vlan:
+    _process: not_implemented
+    config:
+        _process: not_implemented
+        access-vlan:
+            _process: not_implemented
+        interface-mode:
+            _process: not_implemented
+        native-vlan:
+            _process: not_implemented
+        trunk-vlans:
+            _process: not_implemented
+    state:
+        _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-vlan/vlan.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-vlan/vlan.yaml
@@ -1,0 +1,12 @@
+---
+metadata:
+    processor: JSONParser
+
+vlan:
+    _process: not_implemented
+    config:
+        _process: not_implemented
+        vlan-id:
+            _process: not_implemented
+    state:
+        _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/config/openconfig-vlan/vlans.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/config/openconfig-vlan/vlans.yaml
@@ -1,0 +1,26 @@
+---
+metadata:
+    processor: unset
+
+vlans:
+    _process: not_implemented
+    vlan:
+        _process: not_implemented
+        config:
+            _process: not_implemented
+            name:
+                _process: not_implemented
+            status:
+                _process: not_implemented
+            tpid:
+                _process: not_implemented
+            vlan-id:
+                _process: not_implemented
+        members:
+            _process: not_implemented
+            member:
+                _process: not_implemented
+        state:
+            _process: not_implemented
+        vlan-id:
+            _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-if-ip/ipv4.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-if-ip/ipv4.yaml
@@ -1,0 +1,80 @@
+---
+metadata:
+    processor: JSONParser
+
+ipv4:
+    _process: not_implemented
+    addresses:
+        _process: not_implemented
+        address:
+            _process: not_implemented
+            state:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                origin:
+                    _process: not_implemented
+                prefix-length:
+                    _process: not_implemented
+            vrrp:
+                _process: not_implemented
+                vrrp-group:
+                    _process: not_implemented
+                    interface-tracking:
+                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            priority-decrement:
+                                _process: not_implemented
+                            track-interface:
+                                _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        accept-mode:
+                            _process: not_implemented
+                        advertisement-interval:
+                            _process: not_implemented
+                        current-priority:
+                            _process: not_implemented
+                        preempt:
+                            _process: not_implemented
+                        preempt-delay:
+                            _process: not_implemented
+                        priority:
+                            _process: not_implemented
+                        virtual-address:
+                            _process: not_implemented
+                        virtual-router-id:
+                            _process: not_implemented
+    neighbors:
+        _process: not_implemented
+        neighbor:
+            _process: not_implemented
+            state:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                link-layer-address:
+                    _process: not_implemented
+                origin:
+                    _process: not_implemented
+    state:
+        _process: not_implemented
+        enabled:
+            _process: not_implemented
+        mtu:
+            _process: not_implemented
+    unnumbered:
+        _process: not_implemented
+        interface-ref:
+            _process: not_implemented
+            state:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                subinterface:
+                    _process: not_implemented
+        state:
+            _process: not_implemented
+            enabled:
+                _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-if-ip/ipv6.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-if-ip/ipv6.yaml
@@ -1,0 +1,90 @@
+---
+metadata:
+    processor: JSONParser
+
+ipv6:
+    _process: not_implemented
+    addresses:
+        _process: not_implemented
+        address:
+            _process: not_implemented
+            state:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                origin:
+                    _process: not_implemented
+                prefix-length:
+                    _process: not_implemented
+                status:
+                    _process: not_implemented
+            vrrp:
+                _process: not_implemented
+                vrrp-group:
+                    _process: not_implemented
+                    interface-tracking:
+                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            priority-decrement:
+                                _process: not_implemented
+                            track-interface:
+                                _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        accept-mode:
+                            _process: not_implemented
+                        advertisement-interval:
+                            _process: not_implemented
+                        current-priority:
+                            _process: not_implemented
+                        preempt:
+                            _process: not_implemented
+                        preempt-delay:
+                            _process: not_implemented
+                        priority:
+                            _process: not_implemented
+                        virtual-address:
+                            _process: not_implemented
+                        virtual-link-local:
+                            _process: not_implemented
+                        virtual-router-id:
+                            _process: not_implemented
+    neighbors:
+        _process: not_implemented
+        neighbor:
+            _process: not_implemented
+            state:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                is-router:
+                    _process: not_implemented
+                link-layer-address:
+                    _process: not_implemented
+                neighbor-state:
+                    _process: not_implemented
+                origin:
+                    _process: not_implemented
+    state:
+        _process: not_implemented
+        dup-addr-detect-transmits:
+            _process: not_implemented
+        enabled:
+            _process: not_implemented
+        mtu:
+            _process: not_implemented
+    unnumbered:
+        _process: not_implemented
+        interface-ref:
+            _process: not_implemented
+            state:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                subinterface:
+                    _process: not_implemented
+        state:
+            _process: not_implemented
+            enabled:
+                _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-interfaces/interfaces.yaml
@@ -1,0 +1,154 @@
+---
+metadata:
+    processor: JSONParser
+    execute:
+        - method: _rpc
+          kwargs:
+            get: data/openconfig-interfaces:interfaces
+
+interfaces:
+    _process:
+      - from: root_interfaces.0
+        path: openconfig-interfaces:interfaces
+    interface:
+        _process: 
+          - path: interface
+            key: name
+        hold-time:
+            _process: not_implemented
+            state:
+                _process: not_implemented
+                down:
+                    _process: not_implemented
+                up:
+                    _process: not_implemented
+        config:
+          _process: not_implemented
+        state:
+            _process: 
+              - path: state
+            admin-status:
+                _process: 
+                  - path: admin-status
+            counters:
+                _process: 
+                  - path: counters
+                in-broadcast-pkts:
+                    _process: 
+                      - path: in-broadcast-pkts
+                in-discards:
+                    _process: 
+                      - path: in-broadcast-pkts
+                in-errors:
+                    _process: 
+                      - path: in-errors
+                in-multicast-pkts:
+                    _process: 
+                      - path: in-multicast-pkts
+                in-octets:
+                    _process: 
+                      - path: in-octets
+                in-unicast-pkts:
+                    _process: 
+                      - path: in-unicast-pkts
+                in-unknown-protos:
+                    _process: 
+                      - path: in-unknown-protos
+                last-clear:
+                    _process: 
+                      - path: last-clear
+                out-broadcast-pkts:
+                    _process: 
+                      - path: out-broadcast-pkts
+                out-discards:
+                    _process: 
+                      - path: out-discards
+                out-errors:
+                    _process: 
+                      - path: out-errors
+                out-multicast-pkts:
+                    _process: 
+                      - path: out-multicast-pkts
+                out-octets:
+                    _process: 
+                      - path: out-octets
+                out-unicast-pkts:
+                    _process: 
+                      - path: out-unicast-pkts
+            description:
+                _process:
+                  - path: description
+            enabled:
+                _process:
+                  - path: description
+            ifindex:
+                _process:
+                  - path: ifindex
+            last-change:
+                _process:
+                  - path: last-change
+                    value: "{{ value | iso8601_to_unix }}"
+            mtu:
+                _process:
+                  - path: mtu
+            name:
+                _process: unnecessary
+            oper-status:
+                _process:
+                  - path: oper-status
+            type:
+                _process:
+                  - path: type
+                    regexp: ".*:(?P<value>[a-zA-Z]+)"
+        subinterfaces:
+            _process: not_implemented
+            subinterface:
+                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    admin-status:
+                        _process: not_implemented
+                    counters:
+                        _process: not_implemented
+                        in-broadcast-pkts:
+                            _process: not_implemented
+                        in-discards:
+                            _process: not_implemented
+                        in-errors:
+                            _process: not_implemented
+                        in-multicast-pkts:
+                            _process: not_implemented
+                        in-octets:
+                            _process: not_implemented
+                        in-unicast-pkts:
+                            _process: not_implemented
+                        in-unknown-protos:
+                            _process: not_implemented
+                        last-clear:
+                            _process: not_implemented
+                        out-broadcast-pkts:
+                            _process: not_implemented
+                        out-discards:
+                            _process: not_implemented
+                        out-errors:
+                            _process: not_implemented
+                        out-multicast-pkts:
+                            _process: not_implemented
+                        out-octets:
+                            _process: not_implemented
+                        out-unicast-pkts:
+                            _process: not_implemented
+                    description:
+                        _process: not_implemented
+                    enabled:
+                        _process: not_implemented
+                    ifindex:
+                        _process: not_implemented
+                    index:
+                        _process: not_implemented
+                    last-change:
+                        _process: not_implemented
+                    name:
+                        _process: not_implemented
+                    oper-status:
+                        _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-network-instance/network-instances.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-network-instance/network-instances.yaml
@@ -1,0 +1,5376 @@
+---
+metadata:
+    processor: unset
+
+network-instances:
+    _process: not_implemented
+    network-instance:
+        _process: not_implemented
+        afts:
+            _process: not_implemented
+            aft:
+                _process: not_implemented
+                entries:
+                    _process: not_implemented
+                    entry:
+                        _process: not_implemented
+                        match:
+                            _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                ip-dscp:
+                                    _process: not_implemented
+                                ip-prefix:
+                                    _process: not_implemented
+                                ip-protocol:
+                                    _process: not_implemented
+                                l4-dst-port:
+                                    _process: not_implemented
+                                l4-src-port:
+                                    _process: not_implemented
+                                mac-address:
+                                    _process: not_implemented
+                                mpls-label:
+                                    _process: not_implemented
+                                mpls-tc:
+                                    _process: not_implemented
+                        next-hops:
+                            _process: not_implemented
+                            next-hop:
+                                _process: not_implemented
+                                interface-ref:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        interface:
+                                            _process: not_implemented
+                                        subinterface:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    decapsulate-header:
+                                        _process: not_implemented
+                                    encapsulate-header:
+                                        _process: not_implemented
+                                    index:
+                                        _process: not_implemented
+                                    ip-address:
+                                        _process: not_implemented
+                                    mac-address:
+                                        _process: not_implemented
+                                    origin-protocol:
+                                        _process: not_implemented
+                                    popped-mpls-label-stack:
+                                        _process: not_implemented
+                                    pushed-mpls-label-stack:
+                                        _process: not_implemented
+                                    weight:
+                                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            index:
+                                _process: not_implemented
+                            octets-forwarded:
+                                _process: not_implemented
+                            packets-forwarded:
+                                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    address-family:
+                        _process: not_implemented
+        connection-points:
+            _process: not_implemented
+            connection-point:
+                _process: not_implemented
+                endpoints:
+                    _process: not_implemented
+                    endpoint:
+                        _process: not_implemented
+                        local:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                subinterface:
+                                    _process: not_implemented
+                        remote:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                remote-system:
+                                    _process: not_implemented
+                                virtual-circuit-identifier:
+                                    _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            active:
+                                _process: not_implemented
+                            endpoint-id:
+                                _process: not_implemented
+                            precedence:
+                                _process: not_implemented
+                            type:
+                                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    connection-point-id:
+                        _process: not_implemented
+        encapsulation:
+            _process: not_implemented
+            state:
+                _process: not_implemented
+                control-word:
+                    _process: not_implemented
+                encapsulation-type:
+                    _process: not_implemented
+                label-allocation-mode:
+                    _process: not_implemented
+        fdb:
+            _process: not_implemented
+            mac-table:
+                _process: not_implemented
+                entries:
+                    _process: not_implemented
+                    entry:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            age:
+                                _process: not_implemented
+                            entry-type:
+                                _process: not_implemented
+                            mac-address:
+                                _process: not_implemented
+                            vlan:
+                                _process: not_implemented
+            state:
+                _process: not_implemented
+                mac-aging-time:
+                    _process: not_implemented
+                mac-learning:
+                    _process: not_implemented
+                maximum-entries:
+                    _process: not_implemented
+        inter-instance-policies:
+            _process: not_implemented
+            apply-policy:
+                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    default-export-policy:
+                        _process: not_implemented
+                    default-import-policy:
+                        _process: not_implemented
+                    export-policy:
+                        _process: not_implemented
+                    import-policy:
+                        _process: not_implemented
+        interfaces:
+            _process: not_implemented
+            interface:
+                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    associated-address-families:
+                        _process: not_implemented
+                    id:
+                        _process: not_implemented
+                    interface:
+                        _process: not_implemented
+                    subinterface:
+                        _process: not_implemented
+        mpls:
+            _process: not_implemented
+            global:
+                _process: not_implemented
+                interface-attributes:
+                    _process: not_implemented
+                    interface:
+                        _process: not_implemented
+                        interface-ref:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                subinterface:
+                                    _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            interface-id:
+                                _process: not_implemented
+                            mpls-enabled:
+                                _process: not_implemented
+                reserved-label-blocks:
+                    _process: not_implemented
+                    reserved-label-block:
+                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            local-id:
+                                _process: not_implemented
+                            lower-bound:
+                                _process: not_implemented
+                            upper-bound:
+                                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    null-label:
+                        _process: not_implemented
+            lsps:
+                _process: not_implemented
+                constrained-path:
+                    _process: not_implemented
+                    named-explicit-paths:
+                        _process: not_implemented
+                        named-explicit-path:
+                            _process: not_implemented
+                            explicit-route-objects:
+                                _process: not_implemented
+                                explicit-route-object:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        address:
+                                            _process: not_implemented
+                                        hop-type:
+                                            _process: not_implemented
+                                        index:
+                                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                name:
+                                    _process: not_implemented
+                                sid-protection-required:
+                                    _process: not_implemented
+                                sid-selection-mode:
+                                    _process: not_implemented
+                    tunnels:
+                        _process: not_implemented
+                        tunnel:
+                            _process: not_implemented
+                            bandwidth:
+                                _process: not_implemented
+                                auto-bandwidth:
+                                    _process: not_implemented
+                                    overflow:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                            overflow-threshold:
+                                                _process: not_implemented
+                                            trigger-event-count:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        adjust-interval:
+                                            _process: not_implemented
+                                        adjust-threshold:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        max-bw:
+                                            _process: not_implemented
+                                        min-bw:
+                                            _process: not_implemented
+                                    underflow:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                            trigger-event-count:
+                                                _process: not_implemented
+                                            underflow-threshold:
+                                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    set-bandwidth:
+                                        _process: not_implemented
+                                    signaled-bandwidth:
+                                        _process: not_implemented
+                                    specification-type:
+                                        _process: not_implemented
+                            p2p-tunnel-attributes:
+                                _process: not_implemented
+                                p2p-primary-path:
+                                    _process: not_implemented
+                                    p2p-primary-path:
+                                        _process: not_implemented
+                                        admin-groups:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                exclude-group:
+                                                    _process: not_implemented
+                                                include-all-group:
+                                                    _process: not_implemented
+                                                include-any-group:
+                                                    _process: not_implemented
+                                        candidate-secondary-paths:
+                                            _process: not_implemented
+                                            candidate-secondary-path:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    active:
+                                                        _process: not_implemented
+                                                    priority:
+                                                        _process: not_implemented
+                                                    secondary-path:
+                                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            associated-rsvp-session:
+                                                _process: not_implemented
+                                            cspf-tiebreaker:
+                                                _process: not_implemented
+                                            explicit-path-name:
+                                                _process: not_implemented
+                                            hold-priority:
+                                                _process: not_implemented
+                                            name:
+                                                _process: not_implemented
+                                            path-computation-method:
+                                                _process: not_implemented
+                                            path-computation-server:
+                                                _process: not_implemented
+                                            preference:
+                                                _process: not_implemented
+                                            retry-timer:
+                                                _process: not_implemented
+                                            setup-priority:
+                                                _process: not_implemented
+                                            use-cspf:
+                                                _process: not_implemented
+                                p2p-secondary-paths:
+                                    _process: not_implemented
+                                    p2p-secondary-path:
+                                        _process: not_implemented
+                                        admin-groups:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                exclude-group:
+                                                    _process: not_implemented
+                                                include-all-group:
+                                                    _process: not_implemented
+                                                include-any-group:
+                                                    _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            associated-rsvp-session:
+                                                _process: not_implemented
+                                            cspf-tiebreaker:
+                                                _process: not_implemented
+                                            explicit-path-name:
+                                                _process: not_implemented
+                                            hold-priority:
+                                                _process: not_implemented
+                                            name:
+                                                _process: not_implemented
+                                            path-computation-method:
+                                                _process: not_implemented
+                                            path-computation-server:
+                                                _process: not_implemented
+                                            preference:
+                                                _process: not_implemented
+                                            retry-timer:
+                                                _process: not_implemented
+                                            setup-priority:
+                                                _process: not_implemented
+                                            use-cspf:
+                                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    destination:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                admin-status:
+                                    _process: not_implemented
+                                counters:
+                                    _process: not_implemented
+                                    bytes:
+                                        _process: not_implemented
+                                    current-path-time:
+                                        _process: not_implemented
+                                    next-reoptimization-time:
+                                        _process: not_implemented
+                                    online-time:
+                                        _process: not_implemented
+                                    packets:
+                                        _process: not_implemented
+                                    path-changes:
+                                        _process: not_implemented
+                                    state-changes:
+                                        _process: not_implemented
+                                description:
+                                    _process: not_implemented
+                                hold-priority:
+                                    _process: not_implemented
+                                metric:
+                                    _process: not_implemented
+                                metric-type:
+                                    _process: not_implemented
+                                name:
+                                    _process: not_implemented
+                                oper-status:
+                                    _process: not_implemented
+                                preference:
+                                    _process: not_implemented
+                                protection-style-requested:
+                                    _process: not_implemented
+                                reoptimize-timer:
+                                    _process: not_implemented
+                                role:
+                                    _process: not_implemented
+                                setup-priority:
+                                    _process: not_implemented
+                                shortcut-eligible:
+                                    _process: not_implemented
+                                signaling-protocol:
+                                    _process: not_implemented
+                                soft-preemption:
+                                    _process: not_implemented
+                                source:
+                                    _process: not_implemented
+                                type:
+                                    _process: not_implemented
+                static-lsps:
+                    _process: not_implemented
+                    static-lsp:
+                        _process: not_implemented
+                        egress:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                incoming-label:
+                                    _process: not_implemented
+                                next-hop:
+                                    _process: not_implemented
+                                push-label:
+                                    _process: not_implemented
+                        ingress:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                incoming-label:
+                                    _process: not_implemented
+                                next-hop:
+                                    _process: not_implemented
+                                push-label:
+                                    _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            name:
+                                _process: not_implemented
+                        transit:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                incoming-label:
+                                    _process: not_implemented
+                                next-hop:
+                                    _process: not_implemented
+                                push-label:
+                                    _process: not_implemented
+                unconstrained-path:
+                    _process: not_implemented
+                    path-setup-protocol:
+                        _process: not_implemented
+            signaling-protocols:
+                _process: not_implemented
+                rsvp-te:
+                    _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                enable:
+                                    _process: not_implemented
+                                recovery-time:
+                                    _process: not_implemented
+                                restart-time:
+                                    _process: not_implemented
+                        hellos:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                hello-interval:
+                                    _process: not_implemented
+                                refresh-reduction:
+                                    _process: not_implemented
+                        soft-preemption:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                enable:
+                                    _process: not_implemented
+                                soft-preemption-timeout:
+                                    _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            counters:
+                                _process: not_implemented
+                                in-ack-messages:
+                                    _process: not_implemented
+                                in-hello-messages:
+                                    _process: not_implemented
+                                in-path-error-messages:
+                                    _process: not_implemented
+                                in-path-messages:
+                                    _process: not_implemented
+                                in-path-tear-messages:
+                                    _process: not_implemented
+                                in-reservation-error-messages:
+                                    _process: not_implemented
+                                in-reservation-messages:
+                                    _process: not_implemented
+                                in-reservation-tear-messages:
+                                    _process: not_implemented
+                                in-srefresh-messages:
+                                    _process: not_implemented
+                                out-ack-messages:
+                                    _process: not_implemented
+                                out-hello-messages:
+                                    _process: not_implemented
+                                out-path-error-messages:
+                                    _process: not_implemented
+                                out-path-messages:
+                                    _process: not_implemented
+                                out-path-tear-messages:
+                                    _process: not_implemented
+                                out-reservation-error-messages:
+                                    _process: not_implemented
+                                out-reservation-messages:
+                                    _process: not_implemented
+                                out-reservation-tear-messages:
+                                    _process: not_implemented
+                                out-srefresh-messages:
+                                    _process: not_implemented
+                                path-timeouts:
+                                    _process: not_implemented
+                                rate-limited-messages:
+                                    _process: not_implemented
+                                reservation-timeouts:
+                                    _process: not_implemented
+                    interface-attributes:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            authentication:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    authentication-key:
+                                        _process: not_implemented
+                                    enable:
+                                        _process: not_implemented
+                            bandwidth-reservations:
+                                _process: not_implemented
+                                bandwidth-reservation:
+                                    _process: not_implemented
+                                    priority:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        active-reservations-count:
+                                            _process: not_implemented
+                                        available-bandwidth:
+                                            _process: not_implemented
+                                        highwater-mark:
+                                            _process: not_implemented
+                                        priority:
+                                            _process: not_implemented
+                                        reserved-bandwidth:
+                                            _process: not_implemented
+                            hellos:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    hello-interval:
+                                        _process: not_implemented
+                                    refresh-reduction:
+                                        _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                            protection:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    bypass-optimize-interval:
+                                        _process: not_implemented
+                                    link-protection-style-requested:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                counters:
+                                    _process: not_implemented
+                                    in-ack-messages:
+                                        _process: not_implemented
+                                    in-hello-messages:
+                                        _process: not_implemented
+                                    in-path-error-messages:
+                                        _process: not_implemented
+                                    in-path-messages:
+                                        _process: not_implemented
+                                    in-path-tear-messages:
+                                        _process: not_implemented
+                                    in-reservation-error-messages:
+                                        _process: not_implemented
+                                    in-reservation-messages:
+                                        _process: not_implemented
+                                    in-reservation-tear-messages:
+                                        _process: not_implemented
+                                    in-srefresh-messages:
+                                        _process: not_implemented
+                                    out-ack-messages:
+                                        _process: not_implemented
+                                    out-hello-messages:
+                                        _process: not_implemented
+                                    out-path-error-messages:
+                                        _process: not_implemented
+                                    out-path-messages:
+                                        _process: not_implemented
+                                    out-path-tear-messages:
+                                        _process: not_implemented
+                                    out-reservation-error-messages:
+                                        _process: not_implemented
+                                    out-reservation-messages:
+                                        _process: not_implemented
+                                    out-reservation-tear-messages:
+                                        _process: not_implemented
+                                    out-srefresh-messages:
+                                        _process: not_implemented
+                                interface-id:
+                                    _process: not_implemented
+                            subscription:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    subscription:
+                                        _process: not_implemented
+                    neighbors:
+                        _process: not_implemented
+                        neighbor:
+                            _process: not_implemented
+                            address:
+                                _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                address:
+                                    _process: not_implemented
+                                detected-interface:
+                                    _process: not_implemented
+                                neighbor-status:
+                                    _process: not_implemented
+                                refresh-reduction:
+                                    _process: not_implemented
+                    sessions:
+                        _process: not_implemented
+                        session:
+                            _process: not_implemented
+                            local-index:
+                                _process: not_implemented
+                            record-route-objects:
+                                _process: not_implemented
+                                record-route-object:
+                                    _process: not_implemented
+                                    index:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        address:
+                                            _process: not_implemented
+                                        index:
+                                            _process: not_implemented
+                                        reported-flags:
+                                            _process: not_implemented
+                                        reported-label:
+                                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                destination-address:
+                                    _process: not_implemented
+                                label-in:
+                                    _process: not_implemented
+                                label-out:
+                                    _process: not_implemented
+                                local-index:
+                                    _process: not_implemented
+                                lsp-id:
+                                    _process: not_implemented
+                                protection-requested:
+                                    _process: not_implemented
+                                sender-tspec:
+                                    _process: not_implemented
+                                    peak-data-rate:
+                                        _process: not_implemented
+                                    rate:
+                                        _process: not_implemented
+                                    size:
+                                        _process: not_implemented
+                                session-name:
+                                    _process: not_implemented
+                                source-address:
+                                    _process: not_implemented
+                                status:
+                                    _process: not_implemented
+                                tunnel-id:
+                                    _process: not_implemented
+                                type:
+                                    _process: not_implemented
+                segment-routing:
+                    _process: not_implemented
+                    aggregate-sid-counters:
+                        _process: not_implemented
+                        aggregate-sid-counter:
+                            _process: not_implemented
+                            mpls-label:
+                                _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                in-octets:
+                                    _process: not_implemented
+                                in-pkts:
+                                    _process: not_implemented
+                                mpls-label:
+                                    _process: not_implemented
+                                out-octets:
+                                    _process: not_implemented
+                                out-pkts:
+                                    _process: not_implemented
+                    interfaces:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                            sid-counters:
+                                _process: not_implemented
+                                sid-counter:
+                                    _process: not_implemented
+                                    forwarding-classes:
+                                        _process: not_implemented
+                                        forwarding-class:
+                                            _process: not_implemented
+                                            exp:
+                                                _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                exp:
+                                                    _process: not_implemented
+                                                in-octets:
+                                                    _process: not_implemented
+                                                in-pkts:
+                                                    _process: not_implemented
+                                                out-octets:
+                                                    _process: not_implemented
+                                                out-pkts:
+                                                    _process: not_implemented
+                                    mpls-label:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        in-octets:
+                                            _process: not_implemented
+                                        in-pkts:
+                                            _process: not_implemented
+                                        mpls-label:
+                                            _process: not_implemented
+                                        out-octets:
+                                            _process: not_implemented
+                                        out-pkts:
+                                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                in-octets:
+                                    _process: not_implemented
+                                in-pkts:
+                                    _process: not_implemented
+                                interface-id:
+                                    _process: not_implemented
+                                out-octets:
+                                    _process: not_implemented
+                                out-pkts:
+                                    _process: not_implemented
+            te-global-attributes:
+                _process: not_implemented
+                mpls-admin-groups:
+                    _process: not_implemented
+                    admin-group:
+                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            admin-group-name:
+                                _process: not_implemented
+                            bit-position:
+                                _process: not_implemented
+                srlgs:
+                    _process: not_implemented
+                    srlg:
+                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            cost:
+                                _process: not_implemented
+                            flooding-type:
+                                _process: not_implemented
+                            name:
+                                _process: not_implemented
+                            value:
+                                _process: not_implemented
+                        static-srlg-members:
+                            _process: not_implemented
+                            members-list:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    from-address:
+                                        _process: not_implemented
+                                    to-address:
+                                        _process: not_implemented
+                te-lsp-timers:
+                    _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        cleanup-delay:
+                            _process: not_implemented
+                        install-delay:
+                            _process: not_implemented
+                        reoptimize-timer:
+                            _process: not_implemented
+            te-interface-attributes:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                    igp-flooding-bandwidth:
+                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            delta-percentage:
+                                _process: not_implemented
+                            down-thresholds:
+                                _process: not_implemented
+                            threshold-specification:
+                                _process: not_implemented
+                            threshold-type:
+                                _process: not_implemented
+                            up-down-thresholds:
+                                _process: not_implemented
+                            up-thresholds:
+                                _process: not_implemented
+                    interface-ref:
+                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            interface:
+                                _process: not_implemented
+                            subinterface:
+                                _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        admin-group:
+                            _process: not_implemented
+                        interface-id:
+                            _process: not_implemented
+                        srlg-membership:
+                            _process: not_implemented
+                        te-metric:
+                            _process: not_implemented
+        policy-forwarding:
+            _process: not_implemented
+            interfaces:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                    interface-ref:
+                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            interface:
+                                _process: not_implemented
+                            subinterface:
+                                _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        apply-forwarding-policy:
+                            _process: not_implemented
+                        interface-id:
+                            _process: not_implemented
+            path-selection-groups:
+                _process: not_implemented
+                path-selection-group:
+                    _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        group-id:
+                            _process: not_implemented
+                        mpls-lsp:
+                            _process: not_implemented
+            policies:
+                _process: not_implemented
+                policy:
+                    _process: not_implemented
+                    rules:
+                        _process: not_implemented
+                        rule:
+                            _process: not_implemented
+                            action:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    decapsulate-gre:
+                                        _process: not_implemented
+                                    discard:
+                                        _process: not_implemented
+                                    network-instance:
+                                        _process: not_implemented
+                                    next-hop:
+                                        _process: not_implemented
+                                    path-selection-group:
+                                        _process: not_implemented
+                            ip:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    destination-ip-address:
+                                        _process: not_implemented
+                                    destination-ip-flow-label:
+                                        _process: not_implemented
+                                    dscp:
+                                        _process: not_implemented
+                                    hop-limit:
+                                        _process: not_implemented
+                                    ip-version:
+                                        _process: not_implemented
+                                    protocol:
+                                        _process: not_implemented
+                                    source-ip-address:
+                                        _process: not_implemented
+                                    source-ip-flow-label:
+                                        _process: not_implemented
+                            l2:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    destination-mac:
+                                        _process: not_implemented
+                                    destination-mac-mask:
+                                        _process: not_implemented
+                                    ethertype:
+                                        _process: not_implemented
+                                    source-mac:
+                                        _process: not_implemented
+                                    source-mac-mask:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                matched-octets:
+                                    _process: not_implemented
+                                matched-pkts:
+                                    _process: not_implemented
+                                sequence-id:
+                                    _process: not_implemented
+                            transport:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    destination-port:
+                                        _process: not_implemented
+                                    source-port:
+                                        _process: not_implemented
+                                    tcp-flags:
+                                        _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        policy-id:
+                            _process: not_implemented
+        protocols:
+            _process: not_implemented
+            protocol:
+                _process: not_implemented
+                bgp:
+                    _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        afi-safis:
+                            _process: not_implemented
+                            afi-safi:
+                                _process: not_implemented
+                                graceful-restart:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                ipv4-labeled-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                ipv4-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        send-default-route:
+                                            _process: not_implemented
+                                ipv6-labeled-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                ipv6-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        send-default-route:
+                                            _process: not_implemented
+                                l2vpn-evpn:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                l2vpn-vpls:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                l3vpn-ipv4-multicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                l3vpn-ipv4-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                l3vpn-ipv6-multicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                l3vpn-ipv6-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                route-selection-options:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        advertise-inactive-routes:
+                                            _process: not_implemented
+                                        always-compare-med:
+                                            _process: not_implemented
+                                        enable-aigp:
+                                            _process: not_implemented
+                                        external-compare-router-id:
+                                            _process: not_implemented
+                                        ignore-as-path-length:
+                                            _process: not_implemented
+                                        ignore-next-hop-igp-metric:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    afi-safi-name:
+                                        _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    total-paths:
+                                        _process: not_implemented
+                                    total-prefixes:
+                                        _process: not_implemented
+                                use-multiple-paths:
+                                    _process: not_implemented
+                                    ebgp:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            allow-multiple-as:
+                                                _process: not_implemented
+                                            maximum-paths:
+                                                _process: not_implemented
+                                    ibgp:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            maximum-paths:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                        confederation:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                identifier:
+                                    _process: not_implemented
+                                member-as:
+                                    _process: not_implemented
+                        default-route-distance:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                external-route-distance:
+                                    _process: not_implemented
+                                internal-route-distance:
+                                    _process: not_implemented
+                        dynamic-neighbor-prefixes:
+                            _process: not_implemented
+                            dynamic-neighbor-prefix:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    peer-group:
+                                        _process: not_implemented
+                                    prefix:
+                                        _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                helper-only:
+                                    _process: not_implemented
+                                restart-time:
+                                    _process: not_implemented
+                                stale-routes-time:
+                                    _process: not_implemented
+                        route-selection-options:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                advertise-inactive-routes:
+                                    _process: not_implemented
+                                always-compare-med:
+                                    _process: not_implemented
+                                enable-aigp:
+                                    _process: not_implemented
+                                external-compare-router-id:
+                                    _process: not_implemented
+                                ignore-as-path-length:
+                                    _process: not_implemented
+                                ignore-next-hop-igp-metric:
+                                    _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            as:
+                                _process: not_implemented
+                            router-id:
+                                _process: not_implemented
+                            total-paths:
+                                _process: not_implemented
+                            total-prefixes:
+                                _process: not_implemented
+                        use-multiple-paths:
+                            _process: not_implemented
+                            ebgp:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    allow-multiple-as:
+                                        _process: not_implemented
+                                    maximum-paths:
+                                        _process: not_implemented
+                            ibgp:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    maximum-paths:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                    neighbors:
+                        _process: not_implemented
+                        neighbor:
+                            _process: not_implemented
+                            add-paths:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    eligible-prefix-policy:
+                                        _process: not_implemented
+                                    receive:
+                                        _process: not_implemented
+                                    send-max:
+                                        _process: not_implemented
+                            afi-safis:
+                                _process: not_implemented
+                                afi-safi:
+                                    _process: not_implemented
+                                    apply-policy:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            default-export-policy:
+                                                _process: not_implemented
+                                            default-import-policy:
+                                                _process: not_implemented
+                                            export-policy:
+                                                _process: not_implemented
+                                            import-policy:
+                                                _process: not_implemented
+                                    graceful-restart:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            advertised:
+                                                _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                            received:
+                                                _process: not_implemented
+                                    ipv4-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    ipv4-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                    ipv6-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    ipv6-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                    l2vpn-evpn:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l2vpn-vpls:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l3vpn-ipv4-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l3vpn-ipv4-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l3vpn-ipv6-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l3vpn-ipv6-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        active:
+                                            _process: not_implemented
+                                        afi-safi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        prefixes:
+                                            _process: not_implemented
+                                            installed:
+                                                _process: not_implemented
+                                            received:
+                                                _process: not_implemented
+                                            sent:
+                                                _process: not_implemented
+                                    use-multiple-paths:
+                                        _process: not_implemented
+                                        ebgp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                allow-multiple-as:
+                                                    _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                            apply-policy:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    default-export-policy:
+                                        _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    export-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                            as-path-options:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    allow-own-as:
+                                        _process: not_implemented
+                                    replace-peer-as:
+                                        _process: not_implemented
+                            ebgp-multihop:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    multihop-ttl:
+                                        _process: not_implemented
+                            error-handling:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    erroneous-update-messages:
+                                        _process: not_implemented
+                                    treat-as-withdraw:
+                                        _process: not_implemented
+                            graceful-restart:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    helper-only:
+                                        _process: not_implemented
+                                    local-restarting:
+                                        _process: not_implemented
+                                    mode:
+                                        _process: not_implemented
+                                    peer-restart-time:
+                                        _process: not_implemented
+                                    peer-restarting:
+                                        _process: not_implemented
+                                    restart-time:
+                                        _process: not_implemented
+                                    stale-routes-time:
+                                        _process: not_implemented
+                            logging-options:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    log-neighbor-state-changes:
+                                        _process: not_implemented
+                            route-reflector:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    route-reflector-client:
+                                        _process: not_implemented
+                                    route-reflector-cluster-id:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                auth-password:
+                                    _process: not_implemented
+                                description:
+                                    _process: not_implemented
+                                dynamically-configured:
+                                    _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                established-transitions:
+                                    _process: not_implemented
+                                last-established:
+                                    _process: not_implemented
+                                local-as:
+                                    _process: not_implemented
+                                messages:
+                                    _process: not_implemented
+                                    received:
+                                        NOTIFICATION:
+                                            _process: not_implemented
+                                        UPDATE:
+                                            _process: not_implemented
+                                        _process: not_implemented
+                                    sent:
+                                        NOTIFICATION:
+                                            _process: not_implemented
+                                        UPDATE:
+                                            _process: not_implemented
+                                        _process: not_implemented
+                                neighbor-address:
+                                    _process: not_implemented
+                                peer-as:
+                                    _process: not_implemented
+                                peer-group:
+                                    _process: not_implemented
+                                peer-type:
+                                    _process: not_implemented
+                                queues:
+                                    _process: not_implemented
+                                    input:
+                                        _process: not_implemented
+                                    output:
+                                        _process: not_implemented
+                                remove-private-as:
+                                    _process: not_implemented
+                                route-flap-damping:
+                                    _process: not_implemented
+                                send-community:
+                                    _process: not_implemented
+                                session-state:
+                                    _process: not_implemented
+                                supported-capabilities:
+                                    _process: not_implemented
+                            timers:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    connect-retry:
+                                        _process: not_implemented
+                                    hold-time:
+                                        _process: not_implemented
+                                    keepalive-interval:
+                                        _process: not_implemented
+                                    minimum-advertisement-interval:
+                                        _process: not_implemented
+                                    negotiated-hold-time:
+                                        _process: not_implemented
+                            transport:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    local-address:
+                                        _process: not_implemented
+                                    local-port:
+                                        _process: not_implemented
+                                    mtu-discovery:
+                                        _process: not_implemented
+                                    passive-mode:
+                                        _process: not_implemented
+                                    remote-address:
+                                        _process: not_implemented
+                                    remote-port:
+                                        _process: not_implemented
+                                    tcp-mss:
+                                        _process: not_implemented
+                            use-multiple-paths:
+                                _process: not_implemented
+                                ebgp:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        allow-multiple-as:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                    peer-groups:
+                        _process: not_implemented
+                        peer-group:
+                            _process: not_implemented
+                            add-paths:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    eligible-prefix-policy:
+                                        _process: not_implemented
+                                    receive:
+                                        _process: not_implemented
+                                    send-max:
+                                        _process: not_implemented
+                            afi-safis:
+                                _process: not_implemented
+                                afi-safi:
+                                    _process: not_implemented
+                                    apply-policy:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            default-export-policy:
+                                                _process: not_implemented
+                                            default-import-policy:
+                                                _process: not_implemented
+                                            export-policy:
+                                                _process: not_implemented
+                                            import-policy:
+                                                _process: not_implemented
+                                    graceful-restart:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                    ipv4-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    ipv4-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                    ipv6-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    ipv6-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                    l2vpn-evpn:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l2vpn-vpls:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l3vpn-ipv4-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l3vpn-ipv4-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l3vpn-ipv6-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    l3vpn-ipv6-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                    route-selection-options:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            advertise-inactive-routes:
+                                                _process: not_implemented
+                                            always-compare-med:
+                                                _process: not_implemented
+                                            enable-aigp:
+                                                _process: not_implemented
+                                            external-compare-router-id:
+                                                _process: not_implemented
+                                            ignore-as-path-length:
+                                                _process: not_implemented
+                                            ignore-next-hop-igp-metric:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        afi-safi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                    use-multiple-paths:
+                                        _process: not_implemented
+                                        ebgp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                allow-multiple-as:
+                                                    _process: not_implemented
+                                                maximum-paths:
+                                                    _process: not_implemented
+                                        ibgp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                maximum-paths:
+                                                    _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                            apply-policy:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    default-export-policy:
+                                        _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    export-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                            as-path-options:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    allow-own-as:
+                                        _process: not_implemented
+                                    replace-peer-as:
+                                        _process: not_implemented
+                            ebgp-multihop:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    multihop-ttl:
+                                        _process: not_implemented
+                            error-handling:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    treat-as-withdraw:
+                                        _process: not_implemented
+                            graceful-restart:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    helper-only:
+                                        _process: not_implemented
+                                    restart-time:
+                                        _process: not_implemented
+                                    stale-routes-time:
+                                        _process: not_implemented
+                            logging-options:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    log-neighbor-state-changes:
+                                        _process: not_implemented
+                            route-reflector:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    route-reflector-client:
+                                        _process: not_implemented
+                                    route-reflector-cluster-id:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                auth-password:
+                                    _process: not_implemented
+                                description:
+                                    _process: not_implemented
+                                local-as:
+                                    _process: not_implemented
+                                peer-as:
+                                    _process: not_implemented
+                                peer-group-name:
+                                    _process: not_implemented
+                                peer-type:
+                                    _process: not_implemented
+                                remove-private-as:
+                                    _process: not_implemented
+                                route-flap-damping:
+                                    _process: not_implemented
+                                send-community:
+                                    _process: not_implemented
+                                total-paths:
+                                    _process: not_implemented
+                                total-prefixes:
+                                    _process: not_implemented
+                            timers:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    connect-retry:
+                                        _process: not_implemented
+                                    hold-time:
+                                        _process: not_implemented
+                                    keepalive-interval:
+                                        _process: not_implemented
+                                    minimum-advertisement-interval:
+                                        _process: not_implemented
+                            transport:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    local-address:
+                                        _process: not_implemented
+                                    mtu-discovery:
+                                        _process: not_implemented
+                                    passive-mode:
+                                        _process: not_implemented
+                                    tcp-mss:
+                                        _process: not_implemented
+                            use-multiple-paths:
+                                _process: not_implemented
+                                ebgp:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        allow-multiple-as:
+                                            _process: not_implemented
+                                        maximum-paths:
+                                            _process: not_implemented
+                                ibgp:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        maximum-paths:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                isis:
+                    _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        afi-safi:
+                            _process: not_implemented
+                            af:
+                                _process: not_implemented
+                                multi-topology:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        afi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        safi-name:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    afi-name:
+                                        _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    metric:
+                                        _process: not_implemented
+                                    safi-name:
+                                        _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                helper-only:
+                                    _process: not_implemented
+                        igp-shortcuts:
+                            _process: not_implemented
+                            afi:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    afi-name:
+                                        _process: not_implemented
+                                    nh-type:
+                                        _process: not_implemented
+                        inter-level-propagation-policies:
+                            _process: not_implemented
+                            level1-to-level2:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                            level2-to-level1:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                        lsp-bit:
+                            _process: not_implemented
+                            attached-bit:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    ignore-bit:
+                                        _process: not_implemented
+                                    suppress-bit:
+                                        _process: not_implemented
+                            overload-bit:
+                                _process: not_implemented
+                                reset-triggers:
+                                    _process: not_implemented
+                                    reset-trigger:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            delay:
+                                                _process: not_implemented
+                                            reset-trigger:
+                                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    advertise-high-metric:
+                                        _process: not_implemented
+                                    set-bit:
+                                        _process: not_implemented
+                                    set-bit-on-boot:
+                                        _process: not_implemented
+                        mpls:
+                            _process: not_implemented
+                            igp-ldp-sync:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    post-session-up-delay:
+                                        _process: not_implemented
+                        nsr:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                        reference-bandwidth:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                reference-bandwidth:
+                                    _process: not_implemented
+                        segment-routing:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                srgb:
+                                    _process: not_implemented
+                                srlb:
+                                    _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            authentication-check:
+                                _process: not_implemented
+                            fast-flooding:
+                                _process: not_implemented
+                            iid-tlv:
+                                _process: not_implemented
+                            instance:
+                                _process: not_implemented
+                            level-capability:
+                                _process: not_implemented
+                            max-ecmp-paths:
+                                _process: not_implemented
+                            maximum-area-addresses:
+                                _process: not_implemented
+                            net:
+                                _process: not_implemented
+                            poi-tlv:
+                                _process: not_implemented
+                        timers:
+                            _process: not_implemented
+                            lsp-generation:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    adaptive-timer:
+                                        _process: not_implemented
+                                    lsp-first-wait-interval:
+                                        _process: not_implemented
+                                    lsp-max-wait-interval:
+                                        _process: not_implemented
+                                    lsp-second-wait-interval:
+                                        _process: not_implemented
+                            spf:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    adaptive-timer:
+                                        _process: not_implemented
+                                    spf-first-interval:
+                                        _process: not_implemented
+                                    spf-hold-interval:
+                                        _process: not_implemented
+                                    spf-second-interval:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                lsp-lifetime-interval:
+                                    _process: not_implemented
+                                lsp-refresh-interval:
+                                    _process: not_implemented
+                        transport:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                lsp-mtu-size:
+                                    _process: not_implemented
+                    interfaces:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            afi-safi:
+                                _process: not_implemented
+                                af:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        afi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        safi-name:
+                                            _process: not_implemented
+                            authentication:
+                                _process: not_implemented
+                                key:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        auth-password:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    hello-authentication:
+                                        _process: not_implemented
+                            bfd:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    bfd-tlv:
+                                        _process: not_implemented
+                            circuit-counters:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    adj-changes:
+                                        _process: not_implemented
+                                    adj-number:
+                                        _process: not_implemented
+                                    auth-fails:
+                                        _process: not_implemented
+                                    auth-type-fails:
+                                        _process: not_implemented
+                                    id-field-len-mismatches:
+                                        _process: not_implemented
+                                    init-fails:
+                                        _process: not_implemented
+                                    lan-dis-changes:
+                                        _process: not_implemented
+                                    max-area-address-mismatches:
+                                        _process: not_implemented
+                                    rejected-adj:
+                                        _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                            levels:
+                                _process: not_implemented
+                                level:
+                                    _process: not_implemented
+                                    adjacencies:
+                                        _process: not_implemented
+                                        adjacency:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                adjacency-state:
+                                                    _process: not_implemented
+                                                adjacency-type:
+                                                    _process: not_implemented
+                                                area-address:
+                                                    _process: not_implemented
+                                                dis-system-id:
+                                                    _process: not_implemented
+                                                local-extended-circuit-id:
+                                                    _process: not_implemented
+                                                multi-topology:
+                                                    _process: not_implemented
+                                                neighbor-circuit-type:
+                                                    _process: not_implemented
+                                                neighbor-extended-circuit-id:
+                                                    _process: not_implemented
+                                                neighbor-ipv4-address:
+                                                    _process: not_implemented
+                                                neighbor-ipv6-address:
+                                                    _process: not_implemented
+                                                neighbor-snpa:
+                                                    _process: not_implemented
+                                                nlpid:
+                                                    _process: not_implemented
+                                                priority:
+                                                    _process: not_implemented
+                                                remaining-hold-time:
+                                                    _process: not_implemented
+                                                restart-status:
+                                                    _process: not_implemented
+                                                restart-support:
+                                                    _process: not_implemented
+                                                restart-suppress:
+                                                    _process: not_implemented
+                                                system-id:
+                                                    _process: not_implemented
+                                                topology:
+                                                    _process: not_implemented
+                                                up-time:
+                                                    _process: not_implemented
+                                            system-id:
+                                                _process: not_implemented
+                                    afi-safi:
+                                        _process: not_implemented
+                                        af:
+                                            _process: not_implemented
+                                            segment-routing:
+                                                _process: not_implemented
+                                                adjacency-sids:
+                                                    _process: not_implemented
+                                                    adjacency-sid:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            allocated-dynamic-local:
+                                                                _process: not_implemented
+                                                            group:
+                                                                _process: not_implemented
+                                                            neighbor:
+                                                                _process: not_implemented
+                                                            protection-eligible:
+                                                                _process: not_implemented
+                                                            sid-id:
+                                                                _process: not_implemented
+                                                prefix-sids:
+                                                    _process: not_implemented
+                                                    prefix-sid:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            label-options:
+                                                                _process: not_implemented
+                                                            prefix:
+                                                                _process: not_implemented
+                                                            sid-id:
+                                                                _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                afi-name:
+                                                    _process: not_implemented
+                                                enabled:
+                                                    _process: not_implemented
+                                                metric:
+                                                    _process: not_implemented
+                                                safi-name:
+                                                    _process: not_implemented
+                                    hello-authentication:
+                                        _process: not_implemented
+                                        key:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                auth-password:
+                                                    _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            hello-authentication:
+                                                _process: not_implemented
+                                    packet-counters:
+                                        _process: not_implemented
+                                        cnsp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                dropped:
+                                                    _process: not_implemented
+                                                processed:
+                                                    _process: not_implemented
+                                                received:
+                                                    _process: not_implemented
+                                                retransmit:
+                                                    _process: not_implemented
+                                                sent:
+                                                    _process: not_implemented
+                                        esh:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                dropped:
+                                                    _process: not_implemented
+                                                processed:
+                                                    _process: not_implemented
+                                                received:
+                                                    _process: not_implemented
+                                                retransmit:
+                                                    _process: not_implemented
+                                                sent:
+                                                    _process: not_implemented
+                                        iih:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                dropped:
+                                                    _process: not_implemented
+                                                processed:
+                                                    _process: not_implemented
+                                                received:
+                                                    _process: not_implemented
+                                                retransmit:
+                                                    _process: not_implemented
+                                                sent:
+                                                    _process: not_implemented
+                                        ish:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                dropped:
+                                                    _process: not_implemented
+                                                processed:
+                                                    _process: not_implemented
+                                                received:
+                                                    _process: not_implemented
+                                                retransmit:
+                                                    _process: not_implemented
+                                                sent:
+                                                    _process: not_implemented
+                                        lsp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                dropped:
+                                                    _process: not_implemented
+                                                processed:
+                                                    _process: not_implemented
+                                                received:
+                                                    _process: not_implemented
+                                                retransmit:
+                                                    _process: not_implemented
+                                                sent:
+                                                    _process: not_implemented
+                                        psnp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                dropped:
+                                                    _process: not_implemented
+                                                processed:
+                                                    _process: not_implemented
+                                                received:
+                                                    _process: not_implemented
+                                                retransmit:
+                                                    _process: not_implemented
+                                                sent:
+                                                    _process: not_implemented
+                                        unknown:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                dropped:
+                                                    _process: not_implemented
+                                                processed:
+                                                    _process: not_implemented
+                                                received:
+                                                    _process: not_implemented
+                                                retransmit:
+                                                    _process: not_implemented
+                                                sent:
+                                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        level-number:
+                                            _process: not_implemented
+                                        passive:
+                                            _process: not_implemented
+                                        priority:
+                                            _process: not_implemented
+                                    timers:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            hello-interval:
+                                                _process: not_implemented
+                                            hello-multiplier:
+                                                _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                circuit-type:
+                                    _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                hello-padding:
+                                    _process: not_implemented
+                                interface-id:
+                                    _process: not_implemented
+                                passive:
+                                    _process: not_implemented
+                            timers:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    csnp-interval:
+                                        _process: not_implemented
+                                    lsp-pacing-interval:
+                                        _process: not_implemented
+                    levels:
+                        _process: not_implemented
+                        level:
+                            _process: not_implemented
+                            authentication:
+                                _process: not_implemented
+                                key:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        auth-password:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    csnp-authentication:
+                                        _process: not_implemented
+                                    lsp-authentication:
+                                        _process: not_implemented
+                                    psnp-authentication:
+                                        _process: not_implemented
+                            link-state-database:
+                                _process: not_implemented
+                                lsp:
+                                    _process: not_implemented
+                                    lsp-id:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        checksum:
+                                            _process: not_implemented
+                                        id-length:
+                                            _process: not_implemented
+                                        lsp-id:
+                                            _process: not_implemented
+                                        maximum-area-addresses:
+                                            _process: not_implemented
+                                        pdu-length:
+                                            _process: not_implemented
+                                        pdu-type:
+                                            _process: not_implemented
+                                        remaining-lifetime:
+                                            _process: not_implemented
+                                        sequence-number:
+                                            _process: not_implemented
+                                        version:
+                                            _process: not_implemented
+                                        version2:
+                                            _process: not_implemented
+                                    tlvs:
+                                        _process: not_implemented
+                                        tlv:
+                                            _process: not_implemented
+                                            area-address:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    area-address:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            authentication:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    authentication-key:
+                                                        _process: not_implemented
+                                                    crypto-type:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            extended-ipv4-reachability:
+                                                _process: not_implemented
+                                                prefixes:
+                                                    _process: not_implemented
+                                                    prefix:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            ipv4-prefix:
+                                                                _process: not_implemented
+                                                            metric:
+                                                                _process: not_implemented
+                                                            s-bit:
+                                                                _process: not_implemented
+                                                            up-down:
+                                                                _process: not_implemented
+                                                        subTLVs:
+                                                            _process: not_implemented
+                                                            subTLVs:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        flags:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-source-router-id:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-source-router-id:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-source-router-id:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-source-router-id:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                prefix-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            algorithm:
+                                                                                _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            subtlv-type:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    subtlv-type:
+                                                                        _process: not_implemented
+                                                                subtlv-type:
+                                                                    _process: not_implemented
+                                                                tag:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        tag32:
+                                                                            _process: not_implemented
+                                                                tag64:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        tag64:
+                                                                            _process: not_implemented
+                                                        undefined-subtlvs:
+                                                            _process: not_implemented
+                                                            undefined-subtlv:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    length:
+                                                                        _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                    value:
+                                                                        _process: not_implemented
+                                                                type:
+                                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            extended-is-reachability:
+                                                _process: not_implemented
+                                                neighbors:
+                                                    _process: not_implemented
+                                                    neighbors:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            metric:
+                                                                _process: not_implemented
+                                                            system-id:
+                                                                _process: not_implemented
+                                                        subTLVs:
+                                                            _process: not_implemented
+                                                            subTLVs:
+                                                                _process: not_implemented
+                                                                adjacency-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                            weight:
+                                                                                _process: not_implemented
+                                                                admin-group:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        admin-group:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                available-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        available-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                bandwidth-constraints:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        bandwidth-constraints:
+                                                                            _process: not_implemented
+                                                                        model-id:
+                                                                            _process: not_implemented
+                                                                        reserved:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                extended-admin-group:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        extended-admin-group:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-interface-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-interface-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-neighbor-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-neighbor-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-interface-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-interface-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-neighbor-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-neighbor-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                lan-adjacency-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            neighbor-id:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                            weight:
+                                                                                _process: not_implemented
+                                                                link-attributes:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        local-protection:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-delay:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-delay-variation:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-loss:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        link-loss:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-protection-type:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        link-protection-type:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                max-link-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        max-link-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                max-reservable-link-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        max-reservable-link-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                min-max-link-delay:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        max-delay:
+                                                                            _process: not_implemented
+                                                                        min-delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                residual-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        residual-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    subtlv-type:
+                                                                        _process: not_implemented
+                                                                subtlv-type:
+                                                                    _process: not_implemented
+                                                                te-default-metric:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        te-default-metric:
+                                                                            _process: not_implemented
+                                                                unconstrained-lsp:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        unconstrained-lsp:
+                                                                            _process: not_implemented
+                                                                unreserved-bandwidth:
+                                                                    _process: not_implemented
+                                                                    setup-priority:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            setup-priority:
+                                                                                _process: not_implemented
+                                                                            subtlv-type:
+                                                                                _process: not_implemented
+                                                                            unreserved-bandwidth:
+                                                                                _process: not_implemented
+                                                                utilized-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        utilized-bandwidth:
+                                                                            _process: not_implemented
+                                                        undefined-subtlvs:
+                                                            _process: not_implemented
+                                                            undefined-subtlv:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    length:
+                                                                        _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                    value:
+                                                                        _process: not_implemented
+                                                                type:
+                                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            hostname:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    hostname:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            instance-id:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    instance-id:
+                                                        _process: not_implemented
+                                                    topology-id:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            ipv4-external-reachability:
+                                                _process: not_implemented
+                                                prefixes:
+                                                    _process: not_implemented
+                                                    prefixes:
+                                                        _process: not_implemented
+                                                        default-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                default-metric:
+                                                                    _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                        delay-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                        error-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                        expense-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            ipv4-prefix:
+                                                                _process: not_implemented
+                                                            up-down:
+                                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            ipv4-interface-addresses:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    ipv4-interface-addresses:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            ipv4-internal-reachability:
+                                                _process: not_implemented
+                                                prefixes:
+                                                    _process: not_implemented
+                                                    prefixes:
+                                                        _process: not_implemented
+                                                        default-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                default-metric:
+                                                                    _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                        delay-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                        error-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                        expense-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            ipv4-prefix:
+                                                                _process: not_implemented
+                                                            up-down:
+                                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            ipv4-srlg:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    flags:
+                                                        _process: not_implemented
+                                                    ipv4-interface-address:
+                                                        _process: not_implemented
+                                                    ipv4-neighbor-address:
+                                                        _process: not_implemented
+                                                    psn-number:
+                                                        _process: not_implemented
+                                                    srlg-value:
+                                                        _process: not_implemented
+                                                    system-id:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            ipv4-te-router-id:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    ipv4-te-router-id:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            ipv6-interface-addresses:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    ipv6-interface-addresses:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            ipv6-reachability:
+                                                _process: not_implemented
+                                                prefixes:
+                                                    _process: not_implemented
+                                                    prefixes:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            ipv6-prefix:
+                                                                _process: not_implemented
+                                                            metric:
+                                                                _process: not_implemented
+                                                            s-bit:
+                                                                _process: not_implemented
+                                                            up-down:
+                                                                _process: not_implemented
+                                                            x-bit:
+                                                                _process: not_implemented
+                                                        subTLVs:
+                                                            _process: not_implemented
+                                                            subTLVs:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        flags:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-source-router-id:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-source-router-id:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-source-router-id:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-source-router-id:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                prefix-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            algorithm:
+                                                                                _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            subtlv-type:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    subtlv-type:
+                                                                        _process: not_implemented
+                                                                subtlv-type:
+                                                                    _process: not_implemented
+                                                                tag:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        tag32:
+                                                                            _process: not_implemented
+                                                                tag64:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        tag64:
+                                                                            _process: not_implemented
+                                                        undefined-subtlvs:
+                                                            _process: not_implemented
+                                                            undefined-subtlv:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    length:
+                                                                        _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                    value:
+                                                                        _process: not_implemented
+                                                                type:
+                                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            ipv6-srlg:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    flags:
+                                                        _process: not_implemented
+                                                    ipv6-interface-address:
+                                                        _process: not_implemented
+                                                    ipv6-neighbor-address:
+                                                        _process: not_implemented
+                                                    psn-number:
+                                                        _process: not_implemented
+                                                    srlg-value:
+                                                        _process: not_implemented
+                                                    system-id:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            ipv6-te-router-id:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    ipv6-te-router-id:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            is-reachability:
+                                                _process: not_implemented
+                                                neighbors:
+                                                    _process: not_implemented
+                                                    neighbors:
+                                                        _process: not_implemented
+                                                        default-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                default-metric:
+                                                                    _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                        delay-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                        error-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                        expense-metric:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            system-id:
+                                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            isis-alias-id:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    alias-id:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            isis-neighbor-attribute:
+                                                _process: not_implemented
+                                                neighbors:
+                                                    _process: not_implemented
+                                                    neighbor:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            metric:
+                                                                _process: not_implemented
+                                                            system-id:
+                                                                _process: not_implemented
+                                                        subTLVs:
+                                                            _process: not_implemented
+                                                            subTLVs:
+                                                                _process: not_implemented
+                                                                adjacency-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                            weight:
+                                                                                _process: not_implemented
+                                                                admin-group:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        admin-group:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                available-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        available-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                bandwidth-constraints:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        bandwidth-constraints:
+                                                                            _process: not_implemented
+                                                                        model-id:
+                                                                            _process: not_implemented
+                                                                        reserved:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                extended-admin-group:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        extended-admin-group:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-interface-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-interface-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-neighbor-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-neighbor-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-interface-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-interface-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-neighbor-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-neighbor-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                lan-adjacency-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            neighbor-id:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                            weight:
+                                                                                _process: not_implemented
+                                                                link-attributes:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        local-protection:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-delay:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-delay-variation:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-loss:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        link-loss:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-protection-type:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        link-protection-type:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                max-link-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        max-link-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                max-reservable-link-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        max-reservable-link-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                min-max-link-delay:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        max-delay:
+                                                                            _process: not_implemented
+                                                                        min-delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                residual-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        residual-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    subtlv-type:
+                                                                        _process: not_implemented
+                                                                subtlv-type:
+                                                                    _process: not_implemented
+                                                                te-default-metric:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        te-default-metric:
+                                                                            _process: not_implemented
+                                                                unconstrained-lsp:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        unconstrained-lsp:
+                                                                            _process: not_implemented
+                                                                unreserved-bandwidth:
+                                                                    _process: not_implemented
+                                                                    setup-priority:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            setup-priority:
+                                                                                _process: not_implemented
+                                                                            subtlv-type:
+                                                                                _process: not_implemented
+                                                                            unreserved-bandwidth:
+                                                                                _process: not_implemented
+                                                                utilized-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        utilized-bandwidth:
+                                                                            _process: not_implemented
+                                                        undefined-subtlvs:
+                                                            _process: not_implemented
+                                                            undefined-subtlv:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    length:
+                                                                        _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                    value:
+                                                                        _process: not_implemented
+                                                                type:
+                                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            mt-ipv4-reachability:
+                                                _process: not_implemented
+                                                prefixes:
+                                                    _process: not_implemented
+                                                    prefix:
+                                                        _process: not_implemented
+                                                        mt:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                mt-id:
+                                                                    _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            ipv4-prefix:
+                                                                _process: not_implemented
+                                                            metric:
+                                                                _process: not_implemented
+                                                            s-bit:
+                                                                _process: not_implemented
+                                                            up-down:
+                                                                _process: not_implemented
+                                                        subTLVs:
+                                                            _process: not_implemented
+                                                            subTLVs:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        flags:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-source-router-id:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-source-router-id:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-source-router-id:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-source-router-id:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                prefix-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            algorithm:
+                                                                                _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            subtlv-type:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    subtlv-type:
+                                                                        _process: not_implemented
+                                                                subtlv-type:
+                                                                    _process: not_implemented
+                                                                tag:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        tag32:
+                                                                            _process: not_implemented
+                                                                tag64:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        tag64:
+                                                                            _process: not_implemented
+                                                        undefined-subtlvs:
+                                                            _process: not_implemented
+                                                            undefined-subtlv:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    length:
+                                                                        _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                    value:
+                                                                        _process: not_implemented
+                                                                type:
+                                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            mt-ipv6-reachability:
+                                                _process: not_implemented
+                                                prefixes:
+                                                    _process: not_implemented
+                                                    prefix:
+                                                        _process: not_implemented
+                                                        mt:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                mt-id:
+                                                                    _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            ipv6-prefix:
+                                                                _process: not_implemented
+                                                            metric:
+                                                                _process: not_implemented
+                                                            s-bit:
+                                                                _process: not_implemented
+                                                            up-down:
+                                                                _process: not_implemented
+                                                            x-bit:
+                                                                _process: not_implemented
+                                                        subTLVs:
+                                                            _process: not_implemented
+                                                            subTLVs:
+                                                                _process: not_implemented
+                                                                flags:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        flags:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-source-router-id:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-source-router-id:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-source-router-id:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-source-router-id:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                prefix-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            algorithm:
+                                                                                _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            subtlv-type:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    subtlv-type:
+                                                                        _process: not_implemented
+                                                                subtlv-type:
+                                                                    _process: not_implemented
+                                                                tag:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        tag32:
+                                                                            _process: not_implemented
+                                                                tag64:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        tag64:
+                                                                            _process: not_implemented
+                                                        undefined-subtlvs:
+                                                            _process: not_implemented
+                                                            undefined-subtlv:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    length:
+                                                                        _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                    value:
+                                                                        _process: not_implemented
+                                                                type:
+                                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            mt-isis-neighbor-attribute:
+                                                _process: not_implemented
+                                                neighbors:
+                                                    _process: not_implemented
+                                                    neighbor:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            metric:
+                                                                _process: not_implemented
+                                                            mt-id:
+                                                                _process: not_implemented
+                                                            system-id:
+                                                                _process: not_implemented
+                                                        subTLVs:
+                                                            _process: not_implemented
+                                                            subTLVs:
+                                                                _process: not_implemented
+                                                                adjacency-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                            weight:
+                                                                                _process: not_implemented
+                                                                admin-group:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        admin-group:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                available-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        available-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                bandwidth-constraints:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        bandwidth-constraints:
+                                                                            _process: not_implemented
+                                                                        model-id:
+                                                                            _process: not_implemented
+                                                                        reserved:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                extended-admin-group:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        extended-admin-group:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-interface-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-interface-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-neighbor-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-neighbor-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-interface-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-interface-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-neighbor-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-neighbor-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                lan-adjacency-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            neighbor-id:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                            weight:
+                                                                                _process: not_implemented
+                                                                link-attributes:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        local-protection:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-delay:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-delay-variation:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-loss:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        link-loss:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-protection-type:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        link-protection-type:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                max-link-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        max-link-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                max-reservable-link-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        max-reservable-link-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                min-max-link-delay:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        max-delay:
+                                                                            _process: not_implemented
+                                                                        min-delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                residual-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        residual-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    subtlv-type:
+                                                                        _process: not_implemented
+                                                                subtlv-type:
+                                                                    _process: not_implemented
+                                                                te-default-metric:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        te-default-metric:
+                                                                            _process: not_implemented
+                                                                unconstrained-lsp:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        unconstrained-lsp:
+                                                                            _process: not_implemented
+                                                                unreserved-bandwidth:
+                                                                    _process: not_implemented
+                                                                    setup-priority:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            setup-priority:
+                                                                                _process: not_implemented
+                                                                            subtlv-type:
+                                                                                _process: not_implemented
+                                                                            unreserved-bandwidth:
+                                                                                _process: not_implemented
+                                                                utilized-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        utilized-bandwidth:
+                                                                            _process: not_implemented
+                                                        undefined-subtlvs:
+                                                            _process: not_implemented
+                                                            undefined-subtlv:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    length:
+                                                                        _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                    value:
+                                                                        _process: not_implemented
+                                                                type:
+                                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            mt-isn:
+                                                _process: not_implemented
+                                                neighbors:
+                                                    _process: not_implemented
+                                                    neighbor:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            metric:
+                                                                _process: not_implemented
+                                                            mt-id:
+                                                                _process: not_implemented
+                                                            system-id:
+                                                                _process: not_implemented
+                                                        subTLVs:
+                                                            _process: not_implemented
+                                                            subTLVs:
+                                                                _process: not_implemented
+                                                                adjacency-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                            weight:
+                                                                                _process: not_implemented
+                                                                admin-group:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        admin-group:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                available-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        available-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                bandwidth-constraints:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        bandwidth-constraints:
+                                                                            _process: not_implemented
+                                                                        model-id:
+                                                                            _process: not_implemented
+                                                                        reserved:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                extended-admin-group:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        extended-admin-group:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-interface-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-interface-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv4-neighbor-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv4-neighbor-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-interface-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-interface-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                ipv6-neighbor-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        ipv6-neighbor-address:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                lan-adjacency-sid:
+                                                                    _process: not_implemented
+                                                                    sid:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            flags:
+                                                                                _process: not_implemented
+                                                                            neighbor-id:
+                                                                                _process: not_implemented
+                                                                            value:
+                                                                                _process: not_implemented
+                                                                            weight:
+                                                                                _process: not_implemented
+                                                                link-attributes:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        local-protection:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-delay:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-delay-variation:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-loss:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        link-loss:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                link-protection-type:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        link-protection-type:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                max-link-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        max-link-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                max-reservable-link-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        max-reservable-link-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                min-max-link-delay:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        a-bit:
+                                                                            _process: not_implemented
+                                                                        max-delay:
+                                                                            _process: not_implemented
+                                                                        min-delay:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                residual-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        residual-bandwidth:
+                                                                            _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    subtlv-type:
+                                                                        _process: not_implemented
+                                                                subtlv-type:
+                                                                    _process: not_implemented
+                                                                te-default-metric:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        te-default-metric:
+                                                                            _process: not_implemented
+                                                                unconstrained-lsp:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        unconstrained-lsp:
+                                                                            _process: not_implemented
+                                                                unreserved-bandwidth:
+                                                                    _process: not_implemented
+                                                                    setup-priority:
+                                                                        _process: not_implemented
+                                                                        state:
+                                                                            _process: not_implemented
+                                                                            setup-priority:
+                                                                                _process: not_implemented
+                                                                            subtlv-type:
+                                                                                _process: not_implemented
+                                                                            unreserved-bandwidth:
+                                                                                _process: not_implemented
+                                                                utilized-bandwidth:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        subtlv-type:
+                                                                            _process: not_implemented
+                                                                        utilized-bandwidth:
+                                                                            _process: not_implemented
+                                                        undefined-subtlvs:
+                                                            _process: not_implemented
+                                                            undefined-subtlv:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    length:
+                                                                        _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                    value:
+                                                                        _process: not_implemented
+                                                                type:
+                                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            multi-topology:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                                topologies:
+                                                    _process: not_implemented
+                                                    topology:
+                                                        _process: not_implemented
+                                                        state:
+                                                            MT-ID:
+                                                                _process: not_implemented
+                                                            _process: not_implemented
+                                                            attributes:
+                                                                _process: not_implemented
+                                            nlpid:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    nlpid:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            purge-oi:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    received-system-id:
+                                                        _process: not_implemented
+                                                    source-system-id:
+                                                        _process: not_implemented
+                                                    system-id-count:
+                                                        _process: not_implemented
+                                                    type:
+                                                        _process: not_implemented
+                                            router-capabilities:
+                                                _process: not_implemented
+                                                router-capability:
+                                                    _process: not_implemented
+                                                    state:
+                                                        _process: not_implemented
+                                                        flags:
+                                                            _process: not_implemented
+                                                        router-id:
+                                                            _process: not_implemented
+                                                        type:
+                                                            _process: not_implemented
+                                                    subtlvs:
+                                                        _process: not_implemented
+                                                        subtlvs:
+                                                            _process: not_implemented
+                                                            segment-routing-algorithm:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    segment-routing-algorithm:
+                                                                        _process: not_implemented
+                                                            segment-routing-capability:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    flags:
+                                                                        _process: not_implemented
+                                                                    label:
+                                                                        _process: not_implemented
+                                                                    range:
+                                                                        _process: not_implemented
+                                                                    subtlv-type:
+                                                                        _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                subtlv-type:
+                                                                    _process: not_implemented
+                                                            subtlv-type:
+                                                                _process: not_implemented
+                                                    undefined-subtlvs:
+                                                        _process: not_implemented
+                                                        undefined-subtlv:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                length:
+                                                                    _process: not_implemented
+                                                                type:
+                                                                    _process: not_implemented
+                                                                value:
+                                                                    _process: not_implemented
+                                                            type:
+                                                                _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                type:
+                                                    _process: not_implemented
+                                            type:
+                                                _process: not_implemented
+                                            type-block:
+                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    flags:
+                                                        _process: not_implemented
+                                                    is-type:
+                                                        _process: not_implemented
+                                    undefined-tlvs:
+                                        _process: not_implemented
+                                        undefined-tlv:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                length:
+                                                    _process: not_implemented
+                                                type:
+                                                    _process: not_implemented
+                                                value:
+                                                    _process: not_implemented
+                                            type:
+                                                _process: not_implemented
+                            route-preference:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    external-route-preference:
+                                        _process: not_implemented
+                                    internal-route-preference:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                authentication-check:
+                                    _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                level-number:
+                                    _process: not_implemented
+                                metric-style:
+                                    _process: not_implemented
+                            system-level-counters:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    auth-fails:
+                                        _process: not_implemented
+                                    auth-type-fails:
+                                        _process: not_implemented
+                                    corrupted-lsps:
+                                        _process: not_implemented
+                                    database-overloads:
+                                        _process: not_implemented
+                                    exceed-max-seq-nums:
+                                        _process: not_implemented
+                                    id-len-mismatch:
+                                        _process: not_implemented
+                                    lsp-errors:
+                                        _process: not_implemented
+                                    manual-address-drop-from-areas:
+                                        _process: not_implemented
+                                    max-area-address-mismatches:
+                                        _process: not_implemented
+                                    own-lsp-purges:
+                                        _process: not_implemented
+                                    part-changes:
+                                        _process: not_implemented
+                                    seq-num-skips:
+                                        _process: not_implemented
+                                    spf-runs:
+                                        _process: not_implemented
+                            traffic-engineering:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    ipv4-router-id:
+                                        _process: not_implemented
+                                    ipv6-router-id:
+                                        _process: not_implemented
+                local-aggregates:
+                    _process: not_implemented
+                    aggregate:
+                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            discard:
+                                _process: not_implemented
+                            prefix:
+                                _process: not_implemented
+                            set-tag:
+                                _process: not_implemented
+                ospfv2:
+                    _process: not_implemented
+                    areas:
+                        _process: not_implemented
+                        area:
+                            _process: not_implemented
+                            interfaces:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                    interface-ref:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            interface:
+                                                _process: not_implemented
+                                            subinterface:
+                                                _process: not_implemented
+                                    lsa-filter:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            all:
+                                                _process: not_implemented
+                                    mpls:
+                                        _process: not_implemented
+                                        igp-ldp-sync:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                enabled:
+                                                    _process: not_implemented
+                                                post-session-up-delay:
+                                                    _process: not_implemented
+                                                synchronized:
+                                                    _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            traffic-engineering-metric:
+                                                _process: not_implemented
+                                    neighbors:
+                                        _process: not_implemented
+                                        neighbor:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                                adjacency-state:
+                                                    _process: not_implemented
+                                                backup-designated-router:
+                                                    _process: not_implemented
+                                                dead-time:
+                                                    _process: not_implemented
+                                                designated-router:
+                                                    _process: not_implemented
+                                                last-established-time:
+                                                    _process: not_implemented
+                                                metric:
+                                                    _process: not_implemented
+                                                optional-capabilities:
+                                                    _process: not_implemented
+                                                priority:
+                                                    _process: not_implemented
+                                                retranmission-queue-length:
+                                                    _process: not_implemented
+                                                router-id:
+                                                    _process: not_implemented
+                                                state-changes:
+                                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        authentication-type:
+                                            _process: not_implemented
+                                        hide-network:
+                                            _process: not_implemented
+                                        id:
+                                            _process: not_implemented
+                                        metric:
+                                            _process: not_implemented
+                                        multi-area-adjacency-primary:
+                                            _process: not_implemented
+                                        network-type:
+                                            _process: not_implemented
+                                        passive:
+                                            _process: not_implemented
+                                        priority:
+                                            _process: not_implemented
+                                    timers:
+                                        _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            dead-interval:
+                                                _process: not_implemented
+                                            hello-interval:
+                                                _process: not_implemented
+                                            retransmission-interval:
+                                                _process: not_implemented
+                            lsdb:
+                                _process: not_implemented
+                                lsa-types:
+                                    _process: not_implemented
+                                    lsa-type:
+                                        _process: not_implemented
+                                        lsas:
+                                            _process: not_implemented
+                                            lsa:
+                                                _process: not_implemented
+                                                as-external-lsa:
+                                                    _process: not_implemented
+                                                    state:
+                                                        _process: not_implemented
+                                                        external-route-tag:
+                                                            _process: not_implemented
+                                                        forwarding-address:
+                                                            _process: not_implemented
+                                                        mask:
+                                                            _process: not_implemented
+                                                        metric:
+                                                            _process: not_implemented
+                                                        metric-type:
+                                                            _process: not_implemented
+                                                    types-of-service:
+                                                        _process: not_implemented
+                                                        type-of-service:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                external-route-tag:
+                                                                    _process: not_implemented
+                                                                forwarding-address:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                                tos:
+                                                                    _process: not_implemented
+                                                            tos:
+                                                                _process: not_implemented
+                                                link-state-id:
+                                                    _process: not_implemented
+                                                network-lsa:
+                                                    _process: not_implemented
+                                                    state:
+                                                        _process: not_implemented
+                                                        attached-router:
+                                                            _process: not_implemented
+                                                        network-mask:
+                                                            _process: not_implemented
+                                                nssa-external-lsa:
+                                                    _process: not_implemented
+                                                    state:
+                                                        _process: not_implemented
+                                                        external-route-tag:
+                                                            _process: not_implemented
+                                                        forwarding-address:
+                                                            _process: not_implemented
+                                                        mask:
+                                                            _process: not_implemented
+                                                        metric:
+                                                            _process: not_implemented
+                                                        metric-type:
+                                                            _process: not_implemented
+                                                        propagate:
+                                                            _process: not_implemented
+                                                    types-of-service:
+                                                        _process: not_implemented
+                                                        type-of-service:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                external-route-tag:
+                                                                    _process: not_implemented
+                                                                forwarding-address:
+                                                                    _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                                tos:
+                                                                    _process: not_implemented
+                                                            tos:
+                                                                _process: not_implemented
+                                                opaque-lsa:
+                                                    _process: not_implemented
+                                                    extended-link:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            link-data:
+                                                                _process: not_implemented
+                                                            link-id:
+                                                                _process: not_implemented
+                                                            link-type:
+                                                                _process: not_implemented
+                                                        tlvs:
+                                                            _process: not_implemented
+                                                            tlv:
+                                                                _process: not_implemented
+                                                                adjacency-sid:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        backup:
+                                                                            _process: not_implemented
+                                                                        group:
+                                                                            _process: not_implemented
+                                                                        multi-topology-identifier:
+                                                                            _process: not_implemented
+                                                                        sid-type:
+                                                                            _process: not_implemented
+                                                                        sid-value:
+                                                                            _process: not_implemented
+                                                                        weight:
+                                                                            _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                unknown-tlv:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        length:
+                                                                            _process: not_implemented
+                                                                        type:
+                                                                            _process: not_implemented
+                                                                        value:
+                                                                            _process: not_implemented
+                                                    extended-prefix:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            address-family:
+                                                                _process: not_implemented
+                                                            attached:
+                                                                _process: not_implemented
+                                                            node:
+                                                                _process: not_implemented
+                                                            prefix:
+                                                                _process: not_implemented
+                                                            prefix-length:
+                                                                _process: not_implemented
+                                                            route-type:
+                                                                _process: not_implemented
+                                                        tlvs:
+                                                            _process: not_implemented
+                                                            tlv:
+                                                                _process: not_implemented
+                                                                extended-prefix-range:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        address-family:
+                                                                            _process: not_implemented
+                                                                        inter-area:
+                                                                            _process: not_implemented
+                                                                        prefix:
+                                                                            _process: not_implemented
+                                                                        prefix-length:
+                                                                            _process: not_implemented
+                                                                        range-size:
+                                                                            _process: not_implemented
+                                                                prefix-sid:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        algorithm:
+                                                                            _process: not_implemented
+                                                                        explicit-null:
+                                                                            _process: not_implemented
+                                                                        mapping-server:
+                                                                            _process: not_implemented
+                                                                        multi-topology-identifier:
+                                                                            _process: not_implemented
+                                                                        no-php:
+                                                                            _process: not_implemented
+                                                                        sid-scope:
+                                                                            _process: not_implemented
+                                                                        sid-value:
+                                                                            _process: not_implemented
+                                                                        sid-value-type:
+                                                                            _process: not_implemented
+                                                                sid-label-binding:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        mirroring:
+                                                                            _process: not_implemented
+                                                                        multi-topology-identifier:
+                                                                            _process: not_implemented
+                                                                        weight:
+                                                                            _process: not_implemented
+                                                                    tlvs:
+                                                                        _process: not_implemented
+                                                                        tlv:
+                                                                            _process: not_implemented
+                                                                            ero-metric:
+                                                                                _process: not_implemented
+                                                                                state:
+                                                                                    _process: not_implemented
+                                                                                    metric:
+                                                                                        _process: not_implemented
+                                                                            ero-path:
+                                                                                _process: not_implemented
+                                                                                segments:
+                                                                                    _process: not_implemented
+                                                                                    segment:
+                                                                                        _process: not_implemented
+                                                                                        ipv4-segment:
+                                                                                            _process: not_implemented
+                                                                                            state:
+                                                                                                _process: not_implemented
+                                                                                                address:
+                                                                                                    _process: not_implemented
+                                                                                        state:
+                                                                                            _process: not_implemented
+                                                                                            loose:
+                                                                                                _process: not_implemented
+                                                                                            type:
+                                                                                                _process: not_implemented
+                                                                                        unnumbered-hop:
+                                                                                            _process: not_implemented
+                                                                                            state:
+                                                                                                _process: not_implemented
+                                                                                                interface-id:
+                                                                                                    _process: not_implemented
+                                                                                                router-id:
+                                                                                                    _process: not_implemented
+                                                                            sid-label-binding:
+                                                                                _process: not_implemented
+                                                                                state:
+                                                                                    _process: not_implemented
+                                                                                    sid-type:
+                                                                                        _process: not_implemented
+                                                                                    sid-value:
+                                                                                        _process: not_implemented
+                                                                            state:
+                                                                                _process: not_implemented
+                                                                                type:
+                                                                                    _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                unknown-tlv:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        length:
+                                                                            _process: not_implemented
+                                                                        type:
+                                                                            _process: not_implemented
+                                                                        value:
+                                                                            _process: not_implemented
+                                                    grace-lsa:
+                                                        _process: not_implemented
+                                                        tlvs:
+                                                            _process: not_implemented
+                                                            tlv:
+                                                                _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    ip-interface-address:
+                                                                        _process: not_implemented
+                                                                    period:
+                                                                        _process: not_implemented
+                                                                    reason:
+                                                                        _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                unknown-tlv:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        length:
+                                                                            _process: not_implemented
+                                                                        type:
+                                                                            _process: not_implemented
+                                                                        value:
+                                                                            _process: not_implemented
+                                                    router-information:
+                                                        _process: not_implemented
+                                                        tlvs:
+                                                            _process: not_implemented
+                                                            tlv:
+                                                                _process: not_implemented
+                                                                informational-capabilities:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        experimental-te:
+                                                                            _process: not_implemented
+                                                                        graceful-restart-capable:
+                                                                            _process: not_implemented
+                                                                        graceful-restart-helper:
+                                                                            _process: not_implemented
+                                                                        point-to-point-over-lan:
+                                                                            _process: not_implemented
+                                                                        stub-router:
+                                                                            _process: not_implemented
+                                                                        traffic-engineering:
+                                                                            _process: not_implemented
+                                                                node-administrative-tags:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        administrative-tags:
+                                                                            _process: not_implemented
+                                                                segment-routing-algorithm:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        supported-algorithms:
+                                                                            _process: not_implemented
+                                                                segment-routing-sid-label-range:
+                                                                    _process: not_implemented
+                                                                    tlvs:
+                                                                        _process: not_implemented
+                                                                        tlv:
+                                                                            _process: not_implemented
+                                                                            sid-label:
+                                                                                _process: not_implemented
+                                                                                state:
+                                                                                    _process: not_implemented
+                                                                                    entry-type:
+                                                                                        _process: not_implemented
+                                                                                    first-value:
+                                                                                        _process: not_implemented
+                                                                            state:
+                                                                                _process: not_implemented
+                                                                                range-size:
+                                                                                    _process: not_implemented
+                                                                                type:
+                                                                                    _process: not_implemented
+                                                                            unknown-tlv:
+                                                                                _process: not_implemented
+                                                                                state:
+                                                                                    _process: not_implemented
+                                                                                    length:
+                                                                                        _process: not_implemented
+                                                                                    type:
+                                                                                        _process: not_implemented
+                                                                                    value:
+                                                                                        _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                unknown-tlv:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        length:
+                                                                            _process: not_implemented
+                                                                        type:
+                                                                            _process: not_implemented
+                                                                        value:
+                                                                            _process: not_implemented
+                                                    state:
+                                                        _process: not_implemented
+                                                        scope:
+                                                            _process: not_implemented
+                                                        type:
+                                                            _process: not_implemented
+                                                    traffic-engineering:
+                                                        _process: not_implemented
+                                                        tlvs:
+                                                            _process: not_implemented
+                                                            tlv:
+                                                                _process: not_implemented
+                                                                link:
+                                                                    _process: not_implemented
+                                                                    sub-tlvs:
+                                                                        _process: not_implemented
+                                                                        sub-tlv:
+                                                                            _process: not_implemented
+                                                                            administrative-groups:
+                                                                                _process: not_implemented
+                                                                                admin-group:
+                                                                                    _process: not_implemented
+                                                                                    bit-index:
+                                                                                        _process: not_implemented
+                                                                                    state:
+                                                                                        _process: not_implemented
+                                                                                        bit-index:
+                                                                                            _process: not_implemented
+                                                                                        set:
+                                                                                            _process: not_implemented
+                                                                            state:
+                                                                                _process: not_implemented
+                                                                                link-id:
+                                                                                    _process: not_implemented
+                                                                                link-type:
+                                                                                    _process: not_implemented
+                                                                                local-ip-address:
+                                                                                    _process: not_implemented
+                                                                                maximum-bandwidth:
+                                                                                    _process: not_implemented
+                                                                                maximum-reservable-bandwidth:
+                                                                                    _process: not_implemented
+                                                                                metric:
+                                                                                    _process: not_implemented
+                                                                                remote-ip-address:
+                                                                                    _process: not_implemented
+                                                                                type:
+                                                                                    _process: not_implemented
+                                                                                unknown-type:
+                                                                                    _process: not_implemented
+                                                                                unknown-value:
+                                                                                    _process: not_implemented
+                                                                            unknown-subtlv:
+                                                                                _process: not_implemented
+                                                                                state:
+                                                                                    _process: not_implemented
+                                                                                    length:
+                                                                                        _process: not_implemented
+                                                                                    type:
+                                                                                        _process: not_implemented
+                                                                                    value:
+                                                                                        _process: not_implemented
+                                                                            unreserved-bandwidths:
+                                                                                _process: not_implemented
+                                                                                unreserved-bandwidth:
+                                                                                    _process: not_implemented
+                                                                                    priority:
+                                                                                        _process: not_implemented
+                                                                                    state:
+                                                                                        _process: not_implemented
+                                                                                        priority:
+                                                                                            _process: not_implemented
+                                                                                        unreserved-bandwidth:
+                                                                                            _process: not_implemented
+                                                                node-attribute:
+                                                                    _process: not_implemented
+                                                                    sub-tlvs:
+                                                                        _process: not_implemented
+                                                                        sub-tlv:
+                                                                            _process: not_implemented
+                                                                            state:
+                                                                                _process: not_implemented
+                                                                                local-ipv4-addresses:
+                                                                                    _process: not_implemented
+                                                                                local-ipv6-addresses:
+                                                                                    _process: not_implemented
+                                                                                type:
+                                                                                    _process: not_implemented
+                                                                            unknown-subtlv:
+                                                                                _process: not_implemented
+                                                                                state:
+                                                                                    _process: not_implemented
+                                                                                    length:
+                                                                                        _process: not_implemented
+                                                                                    type:
+                                                                                        _process: not_implemented
+                                                                                    value:
+                                                                                        _process: not_implemented
+                                                                router-address:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        address:
+                                                                            _process: not_implemented
+                                                                state:
+                                                                    _process: not_implemented
+                                                                    type:
+                                                                        _process: not_implemented
+                                                                unknown-tlv:
+                                                                    _process: not_implemented
+                                                                    state:
+                                                                        _process: not_implemented
+                                                                        length:
+                                                                            _process: not_implemented
+                                                                        type:
+                                                                            _process: not_implemented
+                                                                        value:
+                                                                            _process: not_implemented
+                                                    unknown-tlv:
+                                                        _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                            length:
+                                                                _process: not_implemented
+                                                            type:
+                                                                _process: not_implemented
+                                                            value:
+                                                                _process: not_implemented
+                                                router-lsa:
+                                                    _process: not_implemented
+                                                    state:
+                                                        _process: not_implemented
+                                                        link-data:
+                                                            _process: not_implemented
+                                                        link-id:
+                                                            _process: not_implemented
+                                                        metric:
+                                                            _process: not_implemented
+                                                        number-links:
+                                                            _process: not_implemented
+                                                        number-tos-metrics:
+                                                            _process: not_implemented
+                                                        type:
+                                                            _process: not_implemented
+                                                    types-of-service:
+                                                        _process: not_implemented
+                                                        type-of-service:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                                tos:
+                                                                    _process: not_implemented
+                                                            tos:
+                                                                _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                                    advertising-router:
+                                                        _process: not_implemented
+                                                    age:
+                                                        _process: not_implemented
+                                                    checksum:
+                                                        _process: not_implemented
+                                                    link-state-id:
+                                                        _process: not_implemented
+                                                    sequence-number:
+                                                        _process: not_implemented
+                                                summary-lsa:
+                                                    _process: not_implemented
+                                                    state:
+                                                        _process: not_implemented
+                                                        network-mask:
+                                                            _process: not_implemented
+                                                    types-of-service:
+                                                        _process: not_implemented
+                                                        type-of-service:
+                                                            _process: not_implemented
+                                                            state:
+                                                                _process: not_implemented
+                                                                metric:
+                                                                    _process: not_implemented
+                                                                tos:
+                                                                    _process: not_implemented
+                                                            tos:
+                                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                            type:
+                                                _process: not_implemented
+                                        type:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    identifier:
+                                        _process: not_implemented
+                            mpls:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    traffic-engineering-enabled:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                identifier:
+                                    _process: not_implemented
+                            virtual-links:
+                                _process: not_implemented
+                                virtual-link:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        adjacency-state:
+                                            _process: not_implemented
+                                        backup-designated-router:
+                                            _process: not_implemented
+                                        dead-time:
+                                            _process: not_implemented
+                                        designated-router:
+                                            _process: not_implemented
+                                        last-established-time:
+                                            _process: not_implemented
+                                        optional-capabilities:
+                                            _process: not_implemented
+                                        priority:
+                                            _process: not_implemented
+                                        remote-router-id:
+                                            _process: not_implemented
+                                        retranmission-queue-length:
+                                            _process: not_implemented
+                                        state-changes:
+                                            _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                helper-only:
+                                    _process: not_implemented
+                        inter-area-propagation-policies:
+                            _process: not_implemented
+                            inter-area-propagation-policy:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    dst-area:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                    src-area:
+                                        _process: not_implemented
+                        mpls:
+                            _process: not_implemented
+                            igp-ldp-sync:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    post-session-up-delay:
+                                        _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                traffic-engineering-extensions:
+                                    _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            hide-transit-only-networks:
+                                _process: not_implemented
+                            igp-shortcuts:
+                                _process: not_implemented
+                            log-adjacency-changes:
+                                _process: not_implemented
+                            router-id:
+                                _process: not_implemented
+                            summary-route-cost-mode:
+                                _process: not_implemented
+                        timers:
+                            _process: not_implemented
+                            lsa-generation:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    initial-delay:
+                                        _process: not_implemented
+                                    maximum-delay:
+                                        _process: not_implemented
+                                    timer-type:
+                                        _process: not_implemented
+                            max-metric:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    include:
+                                        _process: not_implemented
+                                    set:
+                                        _process: not_implemented
+                                    timeout:
+                                        _process: not_implemented
+                                    trigger:
+                                        _process: not_implemented
+                            spf:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    initial-delay:
+                                        _process: not_implemented
+                                    maximum-delay:
+                                        _process: not_implemented
+                                    timer-type:
+                                        _process: not_implemented
+                state:
+                    _process: not_implemented
+                    default-metric:
+                        _process: not_implemented
+                    enabled:
+                        _process: not_implemented
+                    identifier:
+                        _process: not_implemented
+                    name:
+                        _process: not_implemented
+                static-routes:
+                    _process: not_implemented
+                    static:
+                        _process: not_implemented
+                        next-hops:
+                            _process: not_implemented
+                            next-hop:
+                                _process: not_implemented
+                                interface-ref:
+                                    _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                        interface:
+                                            _process: not_implemented
+                                        subinterface:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                    index:
+                                        _process: not_implemented
+                                    metric:
+                                        _process: not_implemented
+                                    next-hop:
+                                        _process: not_implemented
+                                    recurse:
+                                        _process: not_implemented
+                        state:
+                            _process: not_implemented
+                            prefix:
+                                _process: not_implemented
+                            set-tag:
+                                _process: not_implemented
+        segment-routing:
+            _process: not_implemented
+            srgbs:
+                _process: not_implemented
+                srgb:
+                    _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        dataplane-type:
+                            _process: not_implemented
+                        ipv6-prefixes:
+                            _process: not_implemented
+                        local-id:
+                            _process: not_implemented
+                        mpls-label-blocks:
+                            _process: not_implemented
+                        size:
+                            _process: not_implemented
+                        used:
+                            _process: not_implemented
+            srlbs:
+                _process: not_implemented
+                srlb:
+                    _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        dataplane-type:
+                            _process: not_implemented
+                        ipv6-prefix:
+                            _process: not_implemented
+                        local-id:
+                            _process: not_implemented
+                        mpls-label-block:
+                            _process: not_implemented
+        state:
+            _process: not_implemented
+            description:
+                _process: not_implemented
+            enabled:
+                _process: not_implemented
+            enabled-address-families:
+                _process: not_implemented
+            mtu:
+                _process: not_implemented
+            name:
+                _process: not_implemented
+            route-distinguisher:
+                _process: not_implemented
+            router-id:
+                _process: not_implemented
+            type:
+                _process: not_implemented
+        table-connections:
+            _process: not_implemented
+            table-connection:
+                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    address-family:
+                        _process: not_implemented
+                    default-import-policy:
+                        _process: not_implemented
+                    dst-protocol:
+                        _process: not_implemented
+                    import-policy:
+                        _process: not_implemented
+                    src-protocol:
+                        _process: not_implemented
+        tables:
+            _process: not_implemented
+            table:
+                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    address-family:
+                        _process: not_implemented
+                    protocol:
+                        _process: not_implemented
+        vlans:
+            _process: not_implemented
+            vlan:
+                _process: not_implemented
+                members:
+                    _process: not_implemented
+                    member:
+                        _process: not_implemented
+                        interface-ref:
+                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                subinterface:
+                                    _process: not_implemented
+                state:
+                    _process: not_implemented
+                    name:
+                        _process: not_implemented
+                    status:
+                        _process: not_implemented
+                    tpid:
+                        _process: not_implemented
+                    vlan-id:
+                        _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-platform/components.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-platform/components.yaml
@@ -1,0 +1,56 @@
+---
+metadata:
+    processor: JSONParser
+
+components:
+    _process: not_implemented
+    component:
+        _process: not_implemented
+        properties:
+            _process: not_implemented
+            property:
+                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    configurable:
+                        _process: not_implemented
+                    name:
+                        _process: not_implemented
+                    value:
+                        _process: not_implemented
+        state:
+            _process: not_implemented
+            description:
+                _process: not_implemented
+            id:
+                _process: not_implemented
+            mfg-name:
+                _process: not_implemented
+            name:
+                _process: not_implemented
+            part-no:
+                _process: not_implemented
+            serial-no:
+                _process: not_implemented
+            temperature:
+                _process: not_implemented
+                avg:
+                    _process: not_implemented
+                instant:
+                    _process: not_implemented
+                max:
+                    _process: not_implemented
+                min:
+                    _process: not_implemented
+            type:
+                _process: not_implemented
+            version:
+                _process: not_implemented
+        subcomponents:
+            _process: not_implemented
+            subcomponent:
+                _process: not_implemented
+                state:
+                    _process: not_implemented
+                    name:
+                        _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-platform/hardware-port.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-platform/hardware-port.yaml
@@ -1,0 +1,6 @@
+---
+metadata:
+    processor: JSONParser
+
+hardware-port:
+    _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-vlan/routed-vlan.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-vlan/routed-vlan.yaml
@@ -1,0 +1,10 @@
+---
+metadata:
+    processor: JSONParser
+
+routed-vlan:
+    _process: not_implemented
+    state:
+        _process: not_implemented
+        vlan:
+            _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-vlan/switched-vlan.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-vlan/switched-vlan.yaml
@@ -1,0 +1,16 @@
+---
+metadata:
+    processor: unset
+
+switched-vlan:
+    _process: not_implemented
+    state:
+        _process: not_implemented
+        access-vlan:
+            _process: not_implemented
+        interface-mode:
+            _process: not_implemented
+        native-vlan:
+            _process: not_implemented
+        trunk-vlans:
+            _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-vlan/vlan.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-vlan/vlan.yaml
@@ -1,0 +1,10 @@
+---
+metadata:
+    processor: JSONParser
+
+vlan:
+    _process: not_implemented
+    state:
+        _process: not_implemented
+        vlan-id:
+            _process: not_implemented

--- a/napalm_yang/mappings/iosxe/parsers/state/openconfig-vlan/vlans.yaml
+++ b/napalm_yang/mappings/iosxe/parsers/state/openconfig-vlan/vlans.yaml
@@ -1,0 +1,30 @@
+---
+metadata:
+    processor: unset
+
+vlans:
+    _process: not_implemented
+    vlan:
+        _process: not_implemented
+        members:
+            _process: not_implemented
+            member:
+                _process: not_implemented
+                interface-ref:
+                    _process: not_implemented
+                    state:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                        subinterface:
+                            _process: not_implemented
+        state:
+            _process: not_implemented
+            name:
+                _process: not_implemented
+            status:
+                _process: not_implemented
+            tpid:
+                _process: not_implemented
+            vlan-id:
+                _process: not_implemented

--- a/napalm_yang/mappings/iosxe/translators/openconfig-if-ip/ipv4.yaml
+++ b/napalm_yang/mappings/iosxe/translators/openconfig-if-ip/ipv4.yaml
@@ -1,0 +1,94 @@
+---
+metadata:
+    processor: JSONTranslator
+
+ipv4:
+    _process: not_implemented
+    addresses:
+        _process: not_implemented
+        address:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                prefix-length:
+                    _process: not_implemented
+            ip:
+                _process: not_implemented
+            state:
+                _process: not_implemented
+            vrrp:
+                _process: not_implemented
+                vrrp-group:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        accept-mode:
+                            _process: not_implemented
+                        advertisement-interval:
+                            _process: not_implemented
+                        preempt:
+                            _process: not_implemented
+                        preempt-delay:
+                            _process: not_implemented
+                        priority:
+                            _process: not_implemented
+                        virtual-address:
+                            _process: not_implemented
+                        virtual-router-id:
+                            _process: not_implemented
+                    interface-tracking:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            priority-decrement:
+                                _process: not_implemented
+                            track-interface:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+                    virtual-router-id:
+                        _process: not_implemented
+    config:
+        _process: not_implemented
+        enabled:
+            _process: not_implemented
+        mtu:
+            _process: not_implemented
+    neighbors:
+        _process: not_implemented
+        neighbor:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                link-layer-address:
+                    _process: not_implemented
+            ip:
+                _process: not_implemented
+            state:
+                _process: not_implemented
+    state:
+        _process: not_implemented
+    unnumbered:
+        _process: not_implemented
+        config:
+            _process: not_implemented
+            enabled:
+                _process: not_implemented
+        interface-ref:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                subinterface:
+                    _process: not_implemented
+            state:
+                _process: not_implemented
+        state:
+            _process: not_implemented

--- a/napalm_yang/mappings/iosxe/translators/openconfig-if-ip/ipv6.yaml
+++ b/napalm_yang/mappings/iosxe/translators/openconfig-if-ip/ipv6.yaml
@@ -1,0 +1,98 @@
+---
+metadata:
+    processor: JSONTranslator
+
+ipv6:
+    _process: not_implemented
+    addresses:
+        _process: not_implemented
+        address:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                prefix-length:
+                    _process: not_implemented
+            ip:
+                _process: not_implemented
+            state:
+                _process: not_implemented
+            vrrp:
+                _process: not_implemented
+                vrrp-group:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        accept-mode:
+                            _process: not_implemented
+                        advertisement-interval:
+                            _process: not_implemented
+                        preempt:
+                            _process: not_implemented
+                        preempt-delay:
+                            _process: not_implemented
+                        priority:
+                            _process: not_implemented
+                        virtual-address:
+                            _process: not_implemented
+                        virtual-link-local:
+                            _process: not_implemented
+                        virtual-router-id:
+                            _process: not_implemented
+                    interface-tracking:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            priority-decrement:
+                                _process: not_implemented
+                            track-interface:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+                    virtual-router-id:
+                        _process: not_implemented
+    config:
+        _process: not_implemented
+        dup-addr-detect-transmits:
+            _process: not_implemented
+        enabled:
+            _process: not_implemented
+        mtu:
+            _process: not_implemented
+    neighbors:
+        _process: not_implemented
+        neighbor:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                link-layer-address:
+                    _process: not_implemented
+            ip:
+                _process: not_implemented
+            state:
+                _process: not_implemented
+    state:
+        _process: not_implemented
+    unnumbered:
+        _process: not_implemented
+        config:
+            _process: not_implemented
+            enabled:
+                _process: not_implemented
+        interface-ref:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                subinterface:
+                    _process: not_implemented
+            state:
+                _process: not_implemented
+        state:
+            _process: not_implemented

--- a/napalm_yang/mappings/iosxe/translators/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/iosxe/translators/openconfig-interfaces/interfaces.yaml
@@ -1,0 +1,71 @@
+---
+metadata:
+    processor: JSONTranslator
+    xml_root: interfaces
+
+interfaces:
+    _process: unnecessary
+    interface:
+        _process:
+            - container: interface
+              key_element: name
+              key_value: "{{ interface_key }}"
+        config:
+            _process:
+              - container: config
+            description:
+                _process:
+                    - element: description
+            enabled:
+                _process:
+                    - element: "enabled"
+            mtu:
+                _process:
+                    - element: mtu
+            name:
+                _process:
+                    - element: name
+            type:
+                _process:
+                    - element: type
+        hold-time:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                down:
+                    _process: not_implemented
+                up:
+                    _process: not_implemented
+            state:
+                _process: not_implemented
+        name:
+            _process: unnecessary
+        state:
+            _process: not_implemented
+        subinterfaces:
+            _process: 
+                - container: subinterfaces
+            subinterface:
+                _process:
+                    - container: subinterface
+                      key_element: index
+                      key_value: "{{ subinterface_key }}"
+                config:
+                    _process: 
+                        - container: config
+                    description:
+                        _process:
+                            - element: description
+                    enabled:
+                        _process:
+                            - element: enabled
+                    index:
+                        _process:
+                            - element: index
+                    name:
+                        _process:
+                            - element: name
+                index:
+                    _process: unnecessary
+                state:
+                    _process: unnecessary

--- a/napalm_yang/mappings/iosxe/translators/openconfig-network-instance/network-instances.yaml
+++ b/napalm_yang/mappings/iosxe/translators/openconfig-network-instance/network-instances.yaml
@@ -1,0 +1,2992 @@
+---
+metadata:
+    processor: unset
+
+network-instances:
+    _process: not_implemented
+    network-instance:
+        _process: not_implemented
+        afts:
+            _process: not_implemented
+            aft:
+                _process: not_implemented
+                address-family:
+                    _process: not_implemented
+                config:
+                    _process: not_implemented
+                    address-family:
+                        _process: not_implemented
+                entries:
+                    _process: not_implemented
+                    entry:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            index:
+                                _process: not_implemented
+                        index:
+                            _process: not_implemented
+                        match:
+                            _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        next-hops:
+                            _process: not_implemented
+                            next-hop:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    index:
+                                        _process: not_implemented
+                                index:
+                                    _process: not_implemented
+                                interface-ref:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        interface:
+                                            _process: not_implemented
+                                        subinterface:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        state:
+                            _process: not_implemented
+                state:
+                    _process: not_implemented
+        config:
+            _process: not_implemented
+            description:
+                _process: not_implemented
+            enabled:
+                _process: not_implemented
+            enabled-address-families:
+                _process: not_implemented
+            mtu:
+                _process: not_implemented
+            name:
+                _process: not_implemented
+            route-distinguisher:
+                _process: not_implemented
+            router-id:
+                _process: not_implemented
+            type:
+                _process: not_implemented
+        connection-points:
+            _process: not_implemented
+            connection-point:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    connection-point-id:
+                        _process: not_implemented
+                connection-point-id:
+                    _process: not_implemented
+                endpoints:
+                    _process: not_implemented
+                    endpoint:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            endpoint-id:
+                                _process: not_implemented
+                            precedence:
+                                _process: not_implemented
+                            type:
+                                _process: not_implemented
+                        endpoint-id:
+                            _process: not_implemented
+                        local:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                subinterface:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        remote:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                remote-system:
+                                    _process: not_implemented
+                                virtual-circuit-identifier:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                state:
+                    _process: not_implemented
+        encapsulation:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                control-word:
+                    _process: not_implemented
+                encapsulation-type:
+                    _process: not_implemented
+                label-allocation-mode:
+                    _process: not_implemented
+            state:
+                _process: not_implemented
+        fdb:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                mac-aging-time:
+                    _process: not_implemented
+                mac-learning:
+                    _process: not_implemented
+                maximum-entries:
+                    _process: not_implemented
+            mac-table:
+                _process: not_implemented
+                entries:
+                    _process: not_implemented
+                    entry:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            mac-address:
+                                _process: not_implemented
+                            vlan:
+                                _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        mac-address:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+            state:
+                _process: not_implemented
+        inter-instance-policies:
+            _process: not_implemented
+            apply-policy:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    default-export-policy:
+                        _process: not_implemented
+                    default-import-policy:
+                        _process: not_implemented
+                    export-policy:
+                        _process: not_implemented
+                    import-policy:
+                        _process: not_implemented
+                state:
+                    _process: not_implemented
+        interfaces:
+            _process: not_implemented
+            interface:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    associated-address-families:
+                        _process: not_implemented
+                    id:
+                        _process: not_implemented
+                    interface:
+                        _process: not_implemented
+                    subinterface:
+                        _process: not_implemented
+                id:
+                    _process: not_implemented
+                state:
+                    _process: not_implemented
+        mpls:
+            _process: not_implemented
+            global:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    null-label:
+                        _process: not_implemented
+                interface-attributes:
+                    _process: not_implemented
+                    interface:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            interface-id:
+                                _process: not_implemented
+                            mpls-enabled:
+                                _process: not_implemented
+                        interface-id:
+                            _process: not_implemented
+                        interface-ref:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                subinterface:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                reserved-label-blocks:
+                    _process: not_implemented
+                    reserved-label-block:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            local-id:
+                                _process: not_implemented
+                            lower-bound:
+                                _process: not_implemented
+                            upper-bound:
+                                _process: not_implemented
+                        local-id:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+                state:
+                    _process: not_implemented
+            lsps:
+                _process: not_implemented
+                constrained-path:
+                    _process: not_implemented
+                    named-explicit-paths:
+                        _process: not_implemented
+                        named-explicit-path:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                name:
+                                    _process: not_implemented
+                                sid-protection-required:
+                                    _process: not_implemented
+                                sid-selection-mode:
+                                    _process: not_implemented
+                            explicit-route-objects:
+                                _process: not_implemented
+                                explicit-route-object:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        address:
+                                            _process: not_implemented
+                                        hop-type:
+                                            _process: not_implemented
+                                        index:
+                                            _process: not_implemented
+                                    index:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                            name:
+                                _process: not_implemented
+                            state:
+                                _process: not_implemented
+                    tunnels:
+                        _process: not_implemented
+                        tunnel:
+                            _process: not_implemented
+                            bandwidth:
+                                _process: not_implemented
+                                auto-bandwidth:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        adjust-interval:
+                                            _process: not_implemented
+                                        adjust-threshold:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        max-bw:
+                                            _process: not_implemented
+                                        min-bw:
+                                            _process: not_implemented
+                                    overflow:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                            overflow-threshold:
+                                                _process: not_implemented
+                                            trigger-event-count:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    underflow:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                            trigger-event-count:
+                                                _process: not_implemented
+                                            underflow-threshold:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    set-bandwidth:
+                                        _process: not_implemented
+                                    specification-type:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                admin-status:
+                                    _process: not_implemented
+                                description:
+                                    _process: not_implemented
+                                hold-priority:
+                                    _process: not_implemented
+                                metric:
+                                    _process: not_implemented
+                                metric-type:
+                                    _process: not_implemented
+                                name:
+                                    _process: not_implemented
+                                preference:
+                                    _process: not_implemented
+                                protection-style-requested:
+                                    _process: not_implemented
+                                reoptimize-timer:
+                                    _process: not_implemented
+                                setup-priority:
+                                    _process: not_implemented
+                                shortcut-eligible:
+                                    _process: not_implemented
+                                signaling-protocol:
+                                    _process: not_implemented
+                                soft-preemption:
+                                    _process: not_implemented
+                                source:
+                                    _process: not_implemented
+                                type:
+                                    _process: not_implemented
+                            name:
+                                _process: not_implemented
+                            p2p-tunnel-attributes:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    destination:
+                                        _process: not_implemented
+                                p2p-primary-path:
+                                    _process: not_implemented
+                                    p2p-primary-path:
+                                        _process: not_implemented
+                                        admin-groups:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                exclude-group:
+                                                    _process: not_implemented
+                                                include-all-group:
+                                                    _process: not_implemented
+                                                include-any-group:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        candidate-secondary-paths:
+                                            _process: not_implemented
+                                            candidate-secondary-path:
+                                                _process: not_implemented
+                                                config:
+                                                    _process: not_implemented
+                                                    priority:
+                                                        _process: not_implemented
+                                                    secondary-path:
+                                                        _process: not_implemented
+                                                secondary-path:
+                                                    _process: not_implemented
+                                                state:
+                                                    _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            cspf-tiebreaker:
+                                                _process: not_implemented
+                                            explicit-path-name:
+                                                _process: not_implemented
+                                            hold-priority:
+                                                _process: not_implemented
+                                            name:
+                                                _process: not_implemented
+                                            path-computation-method:
+                                                _process: not_implemented
+                                            path-computation-server:
+                                                _process: not_implemented
+                                            preference:
+                                                _process: not_implemented
+                                            retry-timer:
+                                                _process: not_implemented
+                                            setup-priority:
+                                                _process: not_implemented
+                                            use-cspf:
+                                                _process: not_implemented
+                                        name:
+                                            _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                p2p-secondary-paths:
+                                    _process: not_implemented
+                                    p2p-secondary-path:
+                                        _process: not_implemented
+                                        admin-groups:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                exclude-group:
+                                                    _process: not_implemented
+                                                include-all-group:
+                                                    _process: not_implemented
+                                                include-any-group:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            cspf-tiebreaker:
+                                                _process: not_implemented
+                                            explicit-path-name:
+                                                _process: not_implemented
+                                            hold-priority:
+                                                _process: not_implemented
+                                            name:
+                                                _process: not_implemented
+                                            path-computation-method:
+                                                _process: not_implemented
+                                            path-computation-server:
+                                                _process: not_implemented
+                                            preference:
+                                                _process: not_implemented
+                                            retry-timer:
+                                                _process: not_implemented
+                                            setup-priority:
+                                                _process: not_implemented
+                                            use-cspf:
+                                                _process: not_implemented
+                                        name:
+                                            _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                static-lsps:
+                    _process: not_implemented
+                    static-lsp:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            name:
+                                _process: not_implemented
+                        egress:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                incoming-label:
+                                    _process: not_implemented
+                                next-hop:
+                                    _process: not_implemented
+                                push-label:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        ingress:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                incoming-label:
+                                    _process: not_implemented
+                                next-hop:
+                                    _process: not_implemented
+                                push-label:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        name:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        transit:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                incoming-label:
+                                    _process: not_implemented
+                                next-hop:
+                                    _process: not_implemented
+                                push-label:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                unconstrained-path:
+                    _process: not_implemented
+                    path-setup-protocol:
+                        _process: not_implemented
+            signaling-protocols:
+                _process: not_implemented
+                rsvp-te:
+                    _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enable:
+                                    _process: not_implemented
+                                recovery-time:
+                                    _process: not_implemented
+                                restart-time:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        hellos:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                hello-interval:
+                                    _process: not_implemented
+                                refresh-reduction:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        soft-preemption:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enable:
+                                    _process: not_implemented
+                                soft-preemption-timeout:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    interface-attributes:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            authentication:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    authentication-key:
+                                        _process: not_implemented
+                                    enable:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            bandwidth-reservations:
+                                _process: not_implemented
+                                bandwidth-reservation:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                interface-id:
+                                    _process: not_implemented
+                            hellos:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    hello-interval:
+                                        _process: not_implemented
+                                    refresh-reduction:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            interface-id:
+                                _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            protection:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    bypass-optimize-interval:
+                                        _process: not_implemented
+                                    link-protection-style-requested:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            subscription:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    subscription:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                    neighbors:
+                        _process: not_implemented
+                        neighbor:
+                            _process: not_implemented
+                    sessions:
+                        _process: not_implemented
+                        session:
+                            _process: not_implemented
+                segment-routing:
+                    _process: not_implemented
+                    aggregate-sid-counters:
+                        _process: not_implemented
+                        aggregate-sid-counter:
+                            _process: not_implemented
+                    interfaces:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                interface-id:
+                                    _process: not_implemented
+                            interface-id:
+                                _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            sid-counters:
+                                _process: not_implemented
+                                sid-counter:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+            te-global-attributes:
+                _process: not_implemented
+                mpls-admin-groups:
+                    _process: not_implemented
+                    admin-group:
+                        _process: not_implemented
+                        admin-group-name:
+                            _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            admin-group-name:
+                                _process: not_implemented
+                            bit-position:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                srlgs:
+                    _process: not_implemented
+                    srlg:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            cost:
+                                _process: not_implemented
+                            flooding-type:
+                                _process: not_implemented
+                            name:
+                                _process: not_implemented
+                            value:
+                                _process: not_implemented
+                        name:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        static-srlg-members:
+                            _process: not_implemented
+                            members-list:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    from-address:
+                                        _process: not_implemented
+                                    to-address:
+                                        _process: not_implemented
+                                from-address:
+                                    _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                te-lsp-timers:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        cleanup-delay:
+                            _process: not_implemented
+                        install-delay:
+                            _process: not_implemented
+                        reoptimize-timer:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+            te-interface-attributes:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        admin-group:
+                            _process: not_implemented
+                        interface-id:
+                            _process: not_implemented
+                        srlg-membership:
+                            _process: not_implemented
+                        te-metric:
+                            _process: not_implemented
+                    igp-flooding-bandwidth:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            delta-percentage:
+                                _process: not_implemented
+                            down-thresholds:
+                                _process: not_implemented
+                            threshold-specification:
+                                _process: not_implemented
+                            threshold-type:
+                                _process: not_implemented
+                            up-down-thresholds:
+                                _process: not_implemented
+                            up-thresholds:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    interface-id:
+                        _process: not_implemented
+                    interface-ref:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            interface:
+                                _process: not_implemented
+                            subinterface:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+        name:
+            _process: not_implemented
+        policy-forwarding:
+            _process: not_implemented
+            interfaces:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        apply-forwarding-policy:
+                            _process: not_implemented
+                        interface-id:
+                            _process: not_implemented
+                    interface-id:
+                        _process: not_implemented
+                    interface-ref:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            interface:
+                                _process: not_implemented
+                            subinterface:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                    state:
+                        _process: not_implemented
+            path-selection-groups:
+                _process: not_implemented
+                path-selection-group:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        group-id:
+                            _process: not_implemented
+                        mpls-lsp:
+                            _process: not_implemented
+                    group-id:
+                        _process: not_implemented
+                    state:
+                        _process: not_implemented
+            policies:
+                _process: not_implemented
+                policy:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        policy-id:
+                            _process: not_implemented
+                    policy-id:
+                        _process: not_implemented
+                    rules:
+                        _process: not_implemented
+                        rule:
+                            _process: not_implemented
+                            action:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    decapsulate-gre:
+                                        _process: not_implemented
+                                    discard:
+                                        _process: not_implemented
+                                    network-instance:
+                                        _process: not_implemented
+                                    next-hop:
+                                        _process: not_implemented
+                                    path-selection-group:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                sequence-id:
+                                    _process: not_implemented
+                            ip:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    destination-ip-address:
+                                        _process: not_implemented
+                                    destination-ip-flow-label:
+                                        _process: not_implemented
+                                    dscp:
+                                        _process: not_implemented
+                                    hop-limit:
+                                        _process: not_implemented
+                                    ip-version:
+                                        _process: not_implemented
+                                    protocol:
+                                        _process: not_implemented
+                                    source-ip-address:
+                                        _process: not_implemented
+                                    source-ip-flow-label:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            l2:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    destination-mac:
+                                        _process: not_implemented
+                                    destination-mac-mask:
+                                        _process: not_implemented
+                                    ethertype:
+                                        _process: not_implemented
+                                    source-mac:
+                                        _process: not_implemented
+                                    source-mac-mask:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            sequence-id:
+                                _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            transport:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    destination-port:
+                                        _process: not_implemented
+                                    source-port:
+                                        _process: not_implemented
+                                    tcp-flags:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                    state:
+                        _process: not_implemented
+        protocols:
+            _process: not_implemented
+            protocol:
+                _process: not_implemented
+                bgp:
+                    _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        afi-safis:
+                            _process: not_implemented
+                            afi-safi:
+                                _process: not_implemented
+                                afi-safi-name:
+                                    _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    afi-safi-name:
+                                        _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                graceful-restart:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                ipv4-labeled-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                ipv4-unicast:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        send-default-route:
+                                            _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                ipv6-labeled-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                ipv6-unicast:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        send-default-route:
+                                            _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                l2vpn-evpn:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l2vpn-vpls:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l3vpn-ipv4-multicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l3vpn-ipv4-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l3vpn-ipv6-multicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                l3vpn-ipv6-unicast:
+                                    _process: not_implemented
+                                    prefix-limit:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            max-prefixes:
+                                                _process: not_implemented
+                                            prevent-teardown:
+                                                _process: not_implemented
+                                            restart-timer:
+                                                _process: not_implemented
+                                            shutdown-threshold-pct:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                route-selection-options:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        advertise-inactive-routes:
+                                            _process: not_implemented
+                                        always-compare-med:
+                                            _process: not_implemented
+                                        enable-aigp:
+                                            _process: not_implemented
+                                        external-compare-router-id:
+                                            _process: not_implemented
+                                        ignore-as-path-length:
+                                            _process: not_implemented
+                                        ignore-next-hop-igp-metric:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                                use-multiple-paths:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                    ebgp:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            allow-multiple-as:
+                                                _process: not_implemented
+                                            maximum-paths:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ibgp:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            maximum-paths:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                        confederation:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                identifier:
+                                    _process: not_implemented
+                                member-as:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            as:
+                                _process: not_implemented
+                            router-id:
+                                _process: not_implemented
+                        default-route-distance:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                external-route-distance:
+                                    _process: not_implemented
+                                internal-route-distance:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        dynamic-neighbor-prefixes:
+                            _process: not_implemented
+                            dynamic-neighbor-prefix:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    peer-group:
+                                        _process: not_implemented
+                                    prefix:
+                                        _process: not_implemented
+                                prefix:
+                                    _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                helper-only:
+                                    _process: not_implemented
+                                restart-time:
+                                    _process: not_implemented
+                                stale-routes-time:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        route-selection-options:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                advertise-inactive-routes:
+                                    _process: not_implemented
+                                always-compare-med:
+                                    _process: not_implemented
+                                enable-aigp:
+                                    _process: not_implemented
+                                external-compare-router-id:
+                                    _process: not_implemented
+                                ignore-as-path-length:
+                                    _process: not_implemented
+                                ignore-next-hop-igp-metric:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        use-multiple-paths:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                            ebgp:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    allow-multiple-as:
+                                        _process: not_implemented
+                                    maximum-paths:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            ibgp:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    maximum-paths:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                    neighbors:
+                        _process: not_implemented
+                        neighbor:
+                            _process: not_implemented
+                            add-paths:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    eligible-prefix-policy:
+                                        _process: not_implemented
+                                    receive:
+                                        _process: not_implemented
+                                    send-max:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            afi-safis:
+                                _process: not_implemented
+                                afi-safi:
+                                    _process: not_implemented
+                                    afi-safi-name:
+                                        _process: not_implemented
+                                    apply-policy:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            default-export-policy:
+                                                _process: not_implemented
+                                            default-import-policy:
+                                                _process: not_implemented
+                                            export-policy:
+                                                _process: not_implemented
+                                            import-policy:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        afi-safi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                    graceful-restart:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ipv4-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    ipv4-unicast:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ipv6-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    ipv6-unicast:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    l2vpn-evpn:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l2vpn-vpls:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv4-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv4-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv6-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv6-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    use-multiple-paths:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                        ebgp:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                allow-multiple-as:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                            apply-policy:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-export-policy:
+                                        _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    export-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            as-path-options:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    allow-own-as:
+                                        _process: not_implemented
+                                    replace-peer-as:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                auth-password:
+                                    _process: not_implemented
+                                description:
+                                    _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                local-as:
+                                    _process: not_implemented
+                                neighbor-address:
+                                    _process: not_implemented
+                                peer-as:
+                                    _process: not_implemented
+                                peer-group:
+                                    _process: not_implemented
+                                peer-type:
+                                    _process: not_implemented
+                                remove-private-as:
+                                    _process: not_implemented
+                                route-flap-damping:
+                                    _process: not_implemented
+                                send-community:
+                                    _process: not_implemented
+                            ebgp-multihop:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    multihop-ttl:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            error-handling:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    treat-as-withdraw:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            graceful-restart:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    helper-only:
+                                        _process: not_implemented
+                                    restart-time:
+                                        _process: not_implemented
+                                    stale-routes-time:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            logging-options:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    log-neighbor-state-changes:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            neighbor-address:
+                                _process: not_implemented
+                            route-reflector:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    route-reflector-client:
+                                        _process: not_implemented
+                                    route-reflector-cluster-id:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            timers:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    connect-retry:
+                                        _process: not_implemented
+                                    hold-time:
+                                        _process: not_implemented
+                                    keepalive-interval:
+                                        _process: not_implemented
+                                    minimum-advertisement-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            transport:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    local-address:
+                                        _process: not_implemented
+                                    mtu-discovery:
+                                        _process: not_implemented
+                                    passive-mode:
+                                        _process: not_implemented
+                                    tcp-mss:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            use-multiple-paths:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                ebgp:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        allow-multiple-as:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                    peer-groups:
+                        _process: not_implemented
+                        peer-group:
+                            _process: not_implemented
+                            add-paths:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    eligible-prefix-policy:
+                                        _process: not_implemented
+                                    receive:
+                                        _process: not_implemented
+                                    send-max:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            afi-safis:
+                                _process: not_implemented
+                                afi-safi:
+                                    _process: not_implemented
+                                    afi-safi-name:
+                                        _process: not_implemented
+                                    apply-policy:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            default-export-policy:
+                                                _process: not_implemented
+                                            default-import-policy:
+                                                _process: not_implemented
+                                            export-policy:
+                                                _process: not_implemented
+                                            import-policy:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        afi-safi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                    graceful-restart:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ipv4-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    ipv4-unicast:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    ipv6-labeled-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    ipv6-unicast:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            send-default-route:
+                                                _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    l2vpn-evpn:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l2vpn-vpls:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv4-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv4-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv6-multicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    l3vpn-ipv6-unicast:
+                                        _process: not_implemented
+                                        prefix-limit:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                max-prefixes:
+                                                    _process: not_implemented
+                                                prevent-teardown:
+                                                    _process: not_implemented
+                                                restart-timer:
+                                                    _process: not_implemented
+                                                shutdown-threshold-pct:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    route-selection-options:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            advertise-inactive-routes:
+                                                _process: not_implemented
+                                            always-compare-med:
+                                                _process: not_implemented
+                                            enable-aigp:
+                                                _process: not_implemented
+                                            external-compare-router-id:
+                                                _process: not_implemented
+                                            ignore-as-path-length:
+                                                _process: not_implemented
+                                            ignore-next-hop-igp-metric:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    use-multiple-paths:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            enabled:
+                                                _process: not_implemented
+                                        ebgp:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                allow-multiple-as:
+                                                    _process: not_implemented
+                                                maximum-paths:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        ibgp:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                maximum-paths:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                            apply-policy:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-export-policy:
+                                        _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    export-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            as-path-options:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    allow-own-as:
+                                        _process: not_implemented
+                                    replace-peer-as:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                auth-password:
+                                    _process: not_implemented
+                                description:
+                                    _process: not_implemented
+                                local-as:
+                                    _process: not_implemented
+                                peer-as:
+                                    _process: not_implemented
+                                peer-group-name:
+                                    _process: not_implemented
+                                peer-type:
+                                    _process: not_implemented
+                                remove-private-as:
+                                    _process: not_implemented
+                                route-flap-damping:
+                                    _process: not_implemented
+                                send-community:
+                                    _process: not_implemented
+                            ebgp-multihop:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    multihop-ttl:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            error-handling:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    treat-as-withdraw:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            graceful-restart:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    helper-only:
+                                        _process: not_implemented
+                                    restart-time:
+                                        _process: not_implemented
+                                    stale-routes-time:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            logging-options:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    log-neighbor-state-changes:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            peer-group-name:
+                                _process: not_implemented
+                            route-reflector:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    route-reflector-client:
+                                        _process: not_implemented
+                                    route-reflector-cluster-id:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            timers:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    connect-retry:
+                                        _process: not_implemented
+                                    hold-time:
+                                        _process: not_implemented
+                                    keepalive-interval:
+                                        _process: not_implemented
+                                    minimum-advertisement-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            transport:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    local-address:
+                                        _process: not_implemented
+                                    mtu-discovery:
+                                        _process: not_implemented
+                                    passive-mode:
+                                        _process: not_implemented
+                                    tcp-mss:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            use-multiple-paths:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                ebgp:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        allow-multiple-as:
+                                            _process: not_implemented
+                                        maximum-paths:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                ibgp:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        maximum-paths:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                config:
+                    _process: not_implemented
+                    default-metric:
+                        _process: not_implemented
+                    enabled:
+                        _process: not_implemented
+                    identifier:
+                        _process: not_implemented
+                    name:
+                        _process: not_implemented
+                identifier:
+                    _process: not_implemented
+                isis:
+                    _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        afi-safi:
+                            _process: not_implemented
+                            af:
+                                _process: not_implemented
+                                afi-name:
+                                    _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    afi-name:
+                                        _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    metric:
+                                        _process: not_implemented
+                                    safi-name:
+                                        _process: not_implemented
+                                multi-topology:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        afi-name:
+                                            _process: not_implemented
+                                        safi-name:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                safi-name:
+                                    _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            authentication-check:
+                                _process: not_implemented
+                            fast-flooding:
+                                _process: not_implemented
+                            iid-tlv:
+                                _process: not_implemented
+                            instance:
+                                _process: not_implemented
+                            level-capability:
+                                _process: not_implemented
+                            max-ecmp-paths:
+                                _process: not_implemented
+                            maximum-area-addresses:
+                                _process: not_implemented
+                            net:
+                                _process: not_implemented
+                            poi-tlv:
+                                _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                helper-only:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        igp-shortcuts:
+                            _process: not_implemented
+                            afi:
+                                _process: not_implemented
+                                afi-name:
+                                    _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    afi-name:
+                                        _process: not_implemented
+                                    nh-type:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        inter-level-propagation-policies:
+                            _process: not_implemented
+                            level1-to-level2:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            level2-to-level1:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        lsp-bit:
+                            _process: not_implemented
+                            attached-bit:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    ignore-bit:
+                                        _process: not_implemented
+                                    suppress-bit:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            overload-bit:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    advertise-high-metric:
+                                        _process: not_implemented
+                                    set-bit:
+                                        _process: not_implemented
+                                    set-bit-on-boot:
+                                        _process: not_implemented
+                                reset-triggers:
+                                    _process: not_implemented
+                                    reset-trigger:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            delay:
+                                                _process: not_implemented
+                                            reset-trigger:
+                                                _process: not_implemented
+                                        reset-trigger:
+                                            _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        mpls:
+                            _process: not_implemented
+                            igp-ldp-sync:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    post-session-up-delay:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        nsr:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        reference-bandwidth:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                reference-bandwidth:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        segment-routing:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                srgb:
+                                    _process: not_implemented
+                                srlb:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        timers:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                lsp-lifetime-interval:
+                                    _process: not_implemented
+                                lsp-refresh-interval:
+                                    _process: not_implemented
+                            lsp-generation:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    lsp-first-wait-interval:
+                                        _process: not_implemented
+                                    lsp-max-wait-interval:
+                                        _process: not_implemented
+                                    lsp-second-wait-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            spf:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    spf-first-interval:
+                                        _process: not_implemented
+                                    spf-hold-interval:
+                                        _process: not_implemented
+                                    spf-second-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        transport:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                lsp-mtu-size:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                    interfaces:
+                        _process: not_implemented
+                        interface:
+                            _process: not_implemented
+                            afi-safi:
+                                _process: not_implemented
+                                af:
+                                    _process: not_implemented
+                                    afi-name:
+                                        _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        afi-name:
+                                            _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        safi-name:
+                                            _process: not_implemented
+                                    safi-name:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                            authentication:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    hello-authentication:
+                                        _process: not_implemented
+                                key:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        auth-password:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            bfd:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    bfd-tlv:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            circuit-counters:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                circuit-type:
+                                    _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                hello-padding:
+                                    _process: not_implemented
+                                interface-id:
+                                    _process: not_implemented
+                                passive:
+                                    _process: not_implemented
+                            interface-id:
+                                _process: not_implemented
+                            interface-ref:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    interface:
+                                        _process: not_implemented
+                                    subinterface:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            levels:
+                                _process: not_implemented
+                                level:
+                                    _process: not_implemented
+                                    adjacencies:
+                                        _process: not_implemented
+                                    afi-safi:
+                                        _process: not_implemented
+                                        af:
+                                            _process: not_implemented
+                                            afi-name:
+                                                _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                afi-name:
+                                                    _process: not_implemented
+                                                enabled:
+                                                    _process: not_implemented
+                                                metric:
+                                                    _process: not_implemented
+                                                safi-name:
+                                                    _process: not_implemented
+                                            safi-name:
+                                                _process: not_implemented
+                                            segment-routing:
+                                                _process: not_implemented
+                                                adjacency-sids:
+                                                    _process: not_implemented
+                                                    adjacency-sid:
+                                                        _process: not_implemented
+                                                        config:
+                                                            _process: not_implemented
+                                                            group:
+                                                                _process: not_implemented
+                                                            neighbor:
+                                                                _process: not_implemented
+                                                            protection-eligible:
+                                                                _process: not_implemented
+                                                            sid-id:
+                                                                _process: not_implemented
+                                                        neighbor:
+                                                            _process: not_implemented
+                                                        sid-id:
+                                                            _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                                prefix-sids:
+                                                    _process: not_implemented
+                                                    prefix-sid:
+                                                        _process: not_implemented
+                                                        config:
+                                                            _process: not_implemented
+                                                            label-options:
+                                                                _process: not_implemented
+                                                            prefix:
+                                                                _process: not_implemented
+                                                            sid-id:
+                                                                _process: not_implemented
+                                                        prefix:
+                                                            _process: not_implemented
+                                                        state:
+                                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        enabled:
+                                            _process: not_implemented
+                                        level-number:
+                                            _process: not_implemented
+                                        passive:
+                                            _process: not_implemented
+                                        priority:
+                                            _process: not_implemented
+                                    hello-authentication:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            hello-authentication:
+                                                _process: not_implemented
+                                        key:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                auth-password:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    level-number:
+                                        _process: not_implemented
+                                    packet-counters:
+                                        _process: not_implemented
+                                        cnsp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        esh:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        iih:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        ish:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        lsp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        psnp:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        unknown:
+                                            _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    timers:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            hello-interval:
+                                                _process: not_implemented
+                                            hello-multiplier:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            timers:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    csnp-interval:
+                                        _process: not_implemented
+                                    lsp-pacing-interval:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                    levels:
+                        _process: not_implemented
+                        level:
+                            _process: not_implemented
+                            authentication:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    csnp-authentication:
+                                        _process: not_implemented
+                                    lsp-authentication:
+                                        _process: not_implemented
+                                    psnp-authentication:
+                                        _process: not_implemented
+                                key:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        auth-password:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                authentication-check:
+                                    _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                level-number:
+                                    _process: not_implemented
+                                metric-style:
+                                    _process: not_implemented
+                            level-number:
+                                _process: not_implemented
+                            link-state-database:
+                                _process: not_implemented
+                            route-preference:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    external-route-preference:
+                                        _process: not_implemented
+                                    internal-route-preference:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            system-level-counters:
+                                _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            traffic-engineering:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    ipv4-router-id:
+                                        _process: not_implemented
+                                    ipv6-router-id:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                local-aggregates:
+                    _process: not_implemented
+                    aggregate:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            discard:
+                                _process: not_implemented
+                            prefix:
+                                _process: not_implemented
+                            set-tag:
+                                _process: not_implemented
+                        prefix:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+                name:
+                    _process: not_implemented
+                ospfv2:
+                    _process: not_implemented
+                    areas:
+                        _process: not_implemented
+                        area:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                identifier:
+                                    _process: not_implemented
+                            identifier:
+                                _process: not_implemented
+                            interfaces:
+                                _process: not_implemented
+                                interface:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        authentication-type:
+                                            _process: not_implemented
+                                        hide-network:
+                                            _process: not_implemented
+                                        id:
+                                            _process: not_implemented
+                                        metric:
+                                            _process: not_implemented
+                                        multi-area-adjacency-primary:
+                                            _process: not_implemented
+                                        network-type:
+                                            _process: not_implemented
+                                        passive:
+                                            _process: not_implemented
+                                        priority:
+                                            _process: not_implemented
+                                    id:
+                                        _process: not_implemented
+                                    interface-ref:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            interface:
+                                                _process: not_implemented
+                                            subinterface:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    lsa-filter:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            all:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    mpls:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            traffic-engineering-metric:
+                                                _process: not_implemented
+                                        igp-ldp-sync:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                enabled:
+                                                    _process: not_implemented
+                                                post-session-up-delay:
+                                                    _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                                    neighbors:
+                                        _process: not_implemented
+                                        neighbor:
+                                            _process: not_implemented
+                                            config:
+                                                _process: not_implemented
+                                                metric:
+                                                    _process: not_implemented
+                                                router-id:
+                                                    _process: not_implemented
+                                            router-id:
+                                                _process: not_implemented
+                                            state:
+                                                _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                    timers:
+                                        _process: not_implemented
+                                        config:
+                                            _process: not_implemented
+                                            dead-interval:
+                                                _process: not_implemented
+                                            hello-interval:
+                                                _process: not_implemented
+                                            retransmission-interval:
+                                                _process: not_implemented
+                                        state:
+                                            _process: not_implemented
+                            lsdb:
+                                _process: not_implemented
+                            mpls:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    traffic-engineering-enabled:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                            virtual-links:
+                                _process: not_implemented
+                                virtual-link:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        remote-router-id:
+                                            _process: not_implemented
+                                    remote-router-id:
+                                        _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                    global:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            hide-transit-only-networks:
+                                _process: not_implemented
+                            igp-shortcuts:
+                                _process: not_implemented
+                            log-adjacency-changes:
+                                _process: not_implemented
+                            router-id:
+                                _process: not_implemented
+                            summary-route-cost-mode:
+                                _process: not_implemented
+                        graceful-restart:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                enabled:
+                                    _process: not_implemented
+                                helper-only:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        inter-area-propagation-policies:
+                            _process: not_implemented
+                            inter-area-propagation-policy:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    default-import-policy:
+                                        _process: not_implemented
+                                    dst-area:
+                                        _process: not_implemented
+                                    import-policy:
+                                        _process: not_implemented
+                                    src-area:
+                                        _process: not_implemented
+                                dst-area:
+                                    _process: not_implemented
+                                src-area:
+                                    _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        mpls:
+                            _process: not_implemented
+                            config:
+                                _process: not_implemented
+                                traffic-engineering-extensions:
+                                    _process: not_implemented
+                            igp-ldp-sync:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    enabled:
+                                        _process: not_implemented
+                                    post-session-up-delay:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            state:
+                                _process: not_implemented
+                        state:
+                            _process: not_implemented
+                        timers:
+                            _process: not_implemented
+                            lsa-generation:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    initial-delay:
+                                        _process: not_implemented
+                                    maximum-delay:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            max-metric:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    include:
+                                        _process: not_implemented
+                                    set:
+                                        _process: not_implemented
+                                    timeout:
+                                        _process: not_implemented
+                                    trigger:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                            spf:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    initial-delay:
+                                        _process: not_implemented
+                                    maximum-delay:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                state:
+                    _process: not_implemented
+                static-routes:
+                    _process: not_implemented
+                    static:
+                        _process: not_implemented
+                        config:
+                            _process: not_implemented
+                            prefix:
+                                _process: not_implemented
+                            set-tag:
+                                _process: not_implemented
+                        next-hops:
+                            _process: not_implemented
+                            next-hop:
+                                _process: not_implemented
+                                config:
+                                    _process: not_implemented
+                                    index:
+                                        _process: not_implemented
+                                    metric:
+                                        _process: not_implemented
+                                    next-hop:
+                                        _process: not_implemented
+                                    recurse:
+                                        _process: not_implemented
+                                index:
+                                    _process: not_implemented
+                                interface-ref:
+                                    _process: not_implemented
+                                    config:
+                                        _process: not_implemented
+                                        interface:
+                                            _process: not_implemented
+                                        subinterface:
+                                            _process: not_implemented
+                                    state:
+                                        _process: not_implemented
+                                state:
+                                    _process: not_implemented
+                        prefix:
+                            _process: not_implemented
+                        state:
+                            _process: not_implemented
+        segment-routing:
+            _process: not_implemented
+            srgbs:
+                _process: not_implemented
+                srgb:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        dataplane-type:
+                            _process: not_implemented
+                        ipv6-prefixes:
+                            _process: not_implemented
+                        local-id:
+                            _process: not_implemented
+                        mpls-label-blocks:
+                            _process: not_implemented
+                    local-id:
+                        _process: not_implemented
+                    state:
+                        _process: not_implemented
+            srlbs:
+                _process: not_implemented
+                srlb:
+                    _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        dataplane-type:
+                            _process: not_implemented
+                        ipv6-prefix:
+                            _process: not_implemented
+                        local-id:
+                            _process: not_implemented
+                        mpls-label-block:
+                            _process: not_implemented
+                    local-id:
+                        _process: not_implemented
+                    state:
+                        _process: not_implemented
+        state:
+            _process: not_implemented
+        table-connections:
+            _process: not_implemented
+            table-connection:
+                _process: not_implemented
+                address-family:
+                    _process: not_implemented
+                config:
+                    _process: not_implemented
+                    address-family:
+                        _process: not_implemented
+                    default-import-policy:
+                        _process: not_implemented
+                    dst-protocol:
+                        _process: not_implemented
+                    import-policy:
+                        _process: not_implemented
+                    src-protocol:
+                        _process: not_implemented
+                dst-protocol:
+                    _process: not_implemented
+                src-protocol:
+                    _process: not_implemented
+                state:
+                    _process: not_implemented
+        tables:
+            _process: not_implemented
+            table:
+                _process: not_implemented
+                address-family:
+                    _process: not_implemented
+                config:
+                    _process: not_implemented
+                    address-family:
+                        _process: not_implemented
+                    protocol:
+                        _process: not_implemented
+                protocol:
+                    _process: not_implemented
+                state:
+                    _process: not_implemented
+        vlans:
+            _process: not_implemented
+            vlan:
+                _process: not_implemented
+                config:
+                    _process: not_implemented
+                    name:
+                        _process: not_implemented
+                    status:
+                        _process: not_implemented
+                    tpid:
+                        _process: not_implemented
+                    vlan-id:
+                        _process: not_implemented
+                members:
+                    _process: not_implemented
+                    member:
+                        _process: not_implemented
+                state:
+                    _process: not_implemented
+                vlan-id:
+                    _process: not_implemented

--- a/napalm_yang/mappings/iosxe/translators/openconfig-vlan/routed-vlan.yaml
+++ b/napalm_yang/mappings/iosxe/translators/openconfig-vlan/routed-vlan.yaml
@@ -1,0 +1,12 @@
+---
+metadata:
+    processor: JSONTranslator
+
+routed-vlan:
+    _process: not_implemented
+    config:
+        _process: not_implemented
+        vlan:
+            _process: not_implemented
+    state:
+        _process: not_implemented

--- a/napalm_yang/mappings/iosxe/translators/openconfig-vlan/switched-vlan.yaml
+++ b/napalm_yang/mappings/iosxe/translators/openconfig-vlan/switched-vlan.yaml
@@ -1,0 +1,18 @@
+---
+metadata:
+    processor: unset
+
+switched-vlan:
+    _process: not_implemented
+    config:
+        _process: not_implemented
+        access-vlan:
+            _process: not_implemented
+        interface-mode:
+            _process: not_implemented
+        native-vlan:
+            _process: not_implemented
+        trunk-vlans:
+            _process: not_implemented
+    state:
+        _process: not_implemented

--- a/napalm_yang/mappings/iosxe/translators/openconfig-vlan/vlan.yaml
+++ b/napalm_yang/mappings/iosxe/translators/openconfig-vlan/vlan.yaml
@@ -1,0 +1,12 @@
+---
+metadata:
+    processor: JSONTranslator
+
+vlan:
+    _process: not_implemented
+    config:
+        _process: not_implemented
+        vlan-id:
+            _process: not_implemented
+    state:
+        _process: not_implemented

--- a/napalm_yang/mappings/iosxe/translators/openconfig-vlan/vlans.yaml
+++ b/napalm_yang/mappings/iosxe/translators/openconfig-vlan/vlans.yaml
@@ -1,0 +1,26 @@
+---
+metadata:
+    processor: unset
+
+vlans:
+    _process: not_implemented
+    vlan:
+        _process: not_implemented
+        config:
+            _process: not_implemented
+            name:
+                _process: not_implemented
+            status:
+                _process: not_implemented
+            tpid:
+                _process: not_implemented
+            vlan-id:
+                _process: not_implemented
+        members:
+            _process: not_implemented
+            member:
+                _process: not_implemented
+        state:
+            _process: not_implemented
+        vlan-id:
+            _process: not_implemented

--- a/napalm_yang/parsers/__init__.py
+++ b/napalm_yang/parsers/__init__.py
@@ -5,6 +5,7 @@ from napalm_yang.parsers.xml import XMLParser
 
 from napalm_yang.translators.text import TextTranslator
 from napalm_yang.translators.xml import XMLTranslator
+from napalm_yang.translators.jsont import JSONTranslator
 
 
 def get_parser(parser):
@@ -15,5 +16,6 @@ def get_parser(parser):
         "XMLParser": XMLParser,
         "TextTranslator": TextTranslator,
         "XMLTranslator": XMLTranslator,
+        "JSONTranslator": JSONTranslator
     }
     return parsers[parser]

--- a/napalm_yang/translators/jsont.py
+++ b/napalm_yang/translators/jsont.py
@@ -11,7 +11,7 @@ class JSONTranslator(XMLTranslator):
 
     def post_processing(self, translator):
         data = etree_to_dict(translator.translation)
-        return json.dumps(data, indent=4, separators=(',', ': '))
+        return json.dumps(data, sort_keys=True, indent=4, separators=(',', ': '))
 
 def etree_to_dict(t):
     d = {t.tag: {} if t.attrib else None}

--- a/napalm_yang/translators/jsont.py
+++ b/napalm_yang/translators/jsont.py
@@ -1,0 +1,38 @@
+from napalm_yang.translators.xml import XMLTranslator
+
+from lxml import etree
+import json
+from collections import defaultdict
+
+import logging
+logger = logging.getLogger("napalm-yang")
+
+class JSONTranslator(XMLTranslator):
+
+    def post_processing(self, translator):
+        data = etree_to_dict(translator.translation)
+        return json.dumps(data, indent=4, separators=(',', ': '))
+
+def etree_to_dict(t):
+    d = {t.tag: {} if t.attrib else None}
+    children = list(t)
+    if children:
+        dd = defaultdict(list)
+        for dc in map(etree_to_dict, children):
+            for k, v in dc.iteritems():
+                dd[k].append(v)
+        d = {t.tag: {k:v[0] if len(v) == 1 else v for k, v in sorted(dd.iteritems(), key=lambda (k,v): (v,k))}}
+    if t.attrib:
+        d[t.tag].update(('@' + k, v) for k, v in sorted(t.attrib.iteritems()))
+    if t.text:
+        text = t.text.strip()
+        if text == "True":
+            text = True
+        if text == "False":
+            text = False
+        if children or t.attrib:
+            if text:
+                d[t.tag]['#text'] = text
+        else:
+            d[t.tag] = text
+    return d

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ xmltodict
 PyYAML
 napalm-base
 -e git://github.com/napalm-automation/pyangbind.git@napalm_custom#egg=pyangbind
+python-dateutil

--- a/test/integration/test_profiles.py
+++ b/test/integration/test_profiles.py
@@ -41,6 +41,8 @@ test_parse_models = [
     ["eos", "state", napalm_yang.models.openconfig_interfaces, "default"],
     ["junos", "config", napalm_yang.models.openconfig_network_instance, "default"],
     ["junos", "state", napalm_yang.models.openconfig_interfaces, "default"],
+    ["iosxe", "config", napalm_yang.models.openconfig_interfaces, "default"],
+    ["iosxe", "state", napalm_yang.models.openconfig_interfaces, "default"],
 ]
 
 

--- a/test/integration/test_profiles.py
+++ b/test/integration/test_profiles.py
@@ -43,6 +43,7 @@ test_parse_models = [
     ["junos", "state", napalm_yang.models.openconfig_interfaces, "default"],
     ["iosxe", "config", napalm_yang.models.openconfig_interfaces, "default"],
     ["iosxe", "state", napalm_yang.models.openconfig_interfaces, "default"],
+    ["iosxe", "config", napalm_yang.models.openconfig_network_instance, "default"],
 ]
 
 

--- a/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/expected.json
+++ b/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/expected.json
@@ -1,0 +1,62 @@
+{
+    "interfaces": {
+        "interface": {
+            "GigabitEthernet1": {
+                "config": {
+                    "description": "",
+                    "enabled": true,
+                    "mtu": 1500,
+                    "type": "ethernetCsmacd"
+                },
+                "name": "GigabitEthernet1"
+            },
+            "GigabitEthernet2": {
+                "config": {
+                    "description": "GbE 2",
+                    "enabled": false,
+                    "mtu": 1500,
+                    "type": "ethernetCsmacd"
+                },
+                "name": "GigabitEthernet2",
+                "subinterfaces": {
+                    "subinterface": {
+                        "10": {
+                            "config": {
+                                "description": "GbE 2.10",
+                                "enabled": true,
+                                "name": "GigabitEthernet2.10"
+                            },
+                            "index": "1"
+                        }
+                    }
+                }
+            },
+            "GigabitEthernet3": {
+                "config": {
+                    "enabled": false,
+                    "mtu": 1500,
+                    "type": "ethernetCsmacd"
+                },
+                "name": "GigabitEthernet3"
+            },
+            "Loopback0": {
+                "config": {
+                    "description": "Loopback Zero",
+                    "enabled": true,
+                    "mtu": 1514,
+                    "type": "softwareLoopback"
+                },
+                "name": "Loopback1"
+            },
+             "Loopback1": {
+                "config": {
+                    "description": "Loopback One",
+                    "enabled": true,
+                    "mtu": 1514,
+                    "type": "softwareLoopback"
+                },
+                "name": "Loopback1"
+            }
+        }
+    }
+}

--- a/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/expected.json
+++ b/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/expected.json
@@ -3,59 +3,41 @@
         "interface": {
             "GigabitEthernet1": {
                 "config": {
-                    "description": "",
                     "enabled": true,
-                    "mtu": 1500,
+                    "name": "GigabitEthernet1",
                     "type": "ethernetCsmacd"
                 },
-                "name": "GigabitEthernet1"
+                "name": "GigabitEthernet1",
+                "subinterfaces": {
+                    "subinterface": {
+                        "0": {
+                            "config": {
+                                "enabled": true,
+                                "name": "GigabitEthernet1"
+                            },
+                            "index": "0"
+                        }
+                    }
+                }
             },
             "GigabitEthernet2": {
                 "config": {
-                    "description": "GbE 2",
                     "enabled": false,
-                    "mtu": 1500,
+                    "name": "GigabitEthernet2",
                     "type": "ethernetCsmacd"
                 },
                 "name": "GigabitEthernet2",
                 "subinterfaces": {
                     "subinterface": {
-                        "10": {
+                        "0": {
                             "config": {
-                                "description": "GbE 2.10",
-                                "enabled": true,
-                                "name": "GigabitEthernet2.10"
+                                "enabled": false,
+                                "name": "GigabitEthernet2"
                             },
-                            "index": "1"
+                            "index": "0"
                         }
                     }
                 }
-            },
-            "GigabitEthernet3": {
-                "config": {
-                    "enabled": false,
-                    "mtu": 1500,
-                    "type": "ethernetCsmacd"
-                },
-                "name": "GigabitEthernet3"
-            },
-            "Loopback0": {
-                "config": {
-                    "description": "Loopback Zero",
-                    "enabled": true,
-                    "mtu": 1514,
-                    "type": "softwareLoopback"
-                },
-                "name": "Loopback1"
-            },
-             "Loopback1": {
-                "config": {
-                    "description": "Loopback One",
-                    "enabled": true,
-                    "mtu": 1514,
-                    "type": "softwareLoopback"
-                },
-                "name": "Loopback1"
             }
         }
     }

--- a/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/mocked/cli.1.data_openconfig_interfaces_interfaces.0
+++ b/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/mocked/cli.1.data_openconfig_interfaces_interfaces.0
@@ -1,0 +1,168 @@
+{
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "GigabitEthernet1",
+        "config": {
+          "type": "iana-if-type:ethernetCsmacd",
+          "name": "GigabitEthernet1",
+          "enabled": true
+        },
+        "state": {
+          "type": "iana-if-type:ethernetCsmacd",
+          "name": "GigabitEthernet1",
+          "enabled": true,
+          "ifindex": 0,
+          "admin-status": "UP",
+          "oper-status": "UP",
+          "last-change": "2017-08-14T18:04:35.000007+00:00",
+          "counters": {
+            "in-octets": 275035,
+            "in-unicast-pkts": 2890,
+            "in-broadcast-pkts": 0,
+            "in-multicast-pkts": 0,
+            "in-discards": 0,
+            "in-errors": 0,
+            "in-unknown-protos": 0,
+            "out-octets": 460183,
+            "out-unicast-pkts": 1852,
+            "out-broadcast-pkts": 0,
+            "out-multicast-pkts": 0,
+            "out-discards": 0,
+            "out-errors": 0,
+            "last-clear": "2017-08-14T18:02:55.000183+00:00"
+          }
+        },
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 0,
+              "config": {
+                "index": 0,
+                "name": "GigabitEthernet1",
+                "enabled": true
+              },
+              "state": {
+                "index": 0,
+                "name": "GigabitEthernet1.0",
+                "enabled": true,
+                "admin-status": "UP",
+                "oper-status": "UP",
+                "last-change": "2017-08-14T18:04:35.000007+00:00",
+                "counters": {
+                  "in-octets": 275035,
+                  "in-unicast-pkts": 2890,
+                  "in-broadcast-pkts": 0,
+                  "in-multicast-pkts": 0,
+                  "in-discards": 0,
+                  "in-errors": 0,
+                  "out-octets": 460183,
+                  "out-unicast-pkts": 1852,
+                  "out-broadcast-pkts": 0,
+                  "out-multicast-pkts": 0,
+                  "out-discards": 0,
+                  "out-errors": 0,
+                  "last-clear": "2017-08-14T18:02:55.000183+00:00"
+                }
+              },
+              "openconfig-if-ip:ipv6": {
+                "config": {
+                  "enabled": false
+                },
+                "state": {
+                  "enabled": false
+                }
+              }
+            }
+          ]
+        },
+        "openconfig-if-ethernet:ethernet": {
+          "config": {
+            "auto-negotiate": true
+          }
+        }
+      },
+      {
+        "name": "GigabitEthernet2",
+        "config": {
+          "type": "iana-if-type:ethernetCsmacd",
+          "name": "GigabitEthernet2",
+          "enabled": false
+        },
+        "state": {
+          "type": "iana-if-type:ethernetCsmacd",
+          "name": "GigabitEthernet2",
+          "enabled": false,
+          "ifindex": 0,
+          "admin-status": "DOWN",
+          "oper-status": "DOWN",
+          "last-change": "2017-08-14T18:04:25.000356+00:00",
+          "counters": {
+            "in-octets": 0,
+            "in-unicast-pkts": 0,
+            "in-broadcast-pkts": 0,
+            "in-multicast-pkts": 0,
+            "in-discards": 0,
+            "in-errors": 0,
+            "in-unknown-protos": 0,
+            "out-octets": 258,
+            "out-unicast-pkts": 3,
+            "out-broadcast-pkts": 0,
+            "out-multicast-pkts": 0,
+            "out-discards": 0,
+            "out-errors": 0,
+            "last-clear": "2017-08-14T18:02:55.000082+00:00"
+          }
+        },
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 0,
+              "config": {
+                "index": 0,
+                "name": "GigabitEthernet2",
+                "enabled": false
+              },
+              "state": {
+                "index": 0,
+                "name": "GigabitEthernet2.0",
+                "enabled": false,
+                "admin-status": "DOWN",
+                "oper-status": "DOWN",
+                "last-change": "2017-08-14T18:04:25.000356+00:00",
+                "counters": {
+                  "in-octets": 0,
+                  "in-unicast-pkts": 0,
+                  "in-broadcast-pkts": 0,
+                  "in-multicast-pkts": 0,
+                  "in-discards": 0,
+                  "in-errors": 0,
+                  "out-octets": 258,
+                  "out-unicast-pkts": 3,
+                  "out-broadcast-pkts": 0,
+                  "out-multicast-pkts": 0,
+                  "out-discards": 0,
+                  "out-errors": 0,
+                  "last-clear": "2017-08-14T18:02:55.000082+00:00"
+                }
+              },
+              "openconfig-if-ip:ipv6": {
+                "config": {
+                  "enabled": false
+                },
+                "state": {
+                  "enabled": false
+                }
+              }
+            }
+          ]
+        },
+        "openconfig-if-ethernet:ethernet": {
+          "config": {
+            "auto-negotiate": true
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/translation.txt
+++ b/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/translation.txt
@@ -3,35 +3,35 @@
         "interface": [
             {
                 "config": {
-                    "type": "ethernetCsmacd",
                     "enabled": true,
-                    "name": "GigabitEthernet1"
+                    "name": "GigabitEthernet1",
+                    "type": "ethernetCsmacd"
                 },
                 "name": "GigabitEthernet1",
                 "subinterfaces": {
                     "subinterface": {
-                        "index": "0",
                         "config": {
                             "enabled": true,
                             "name": "GigabitEthernet1"
-                        }
+                        },
+                        "index": "0"
                     }
                 }
             },
             {
                 "config": {
-                    "type": "ethernetCsmacd",
                     "enabled": false,
-                    "name": "GigabitEthernet2"
+                    "name": "GigabitEthernet2",
+                    "type": "ethernetCsmacd"
                 },
                 "name": "GigabitEthernet2",
                 "subinterfaces": {
                     "subinterface": {
-                        "index": "0",
                         "config": {
                             "enabled": false,
                             "name": "GigabitEthernet2"
-                        }
+                        },
+                        "index": "0"
                     }
                 }
             }

--- a/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/translation.txt
+++ b/test/integration/test_profiles/iosxe/openconfig-interfaces/config/default/translation.txt
@@ -1,0 +1,40 @@
+{
+    "interfaces": {
+        "interface": [
+            {
+                "config": {
+                    "type": "ethernetCsmacd",
+                    "enabled": true,
+                    "name": "GigabitEthernet1"
+                },
+                "name": "GigabitEthernet1",
+                "subinterfaces": {
+                    "subinterface": {
+                        "index": "0",
+                        "config": {
+                            "enabled": true,
+                            "name": "GigabitEthernet1"
+                        }
+                    }
+                }
+            },
+            {
+                "config": {
+                    "type": "ethernetCsmacd",
+                    "enabled": false,
+                    "name": "GigabitEthernet2"
+                },
+                "name": "GigabitEthernet2",
+                "subinterfaces": {
+                    "subinterface": {
+                        "index": "0",
+                        "config": {
+                            "enabled": false,
+                            "name": "GigabitEthernet2"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/test/integration/test_profiles/iosxe/openconfig-interfaces/state/default/expected.json
+++ b/test/integration/test_profiles/iosxe/openconfig-interfaces/state/default/expected.json
@@ -1,0 +1,58 @@
+{
+    "interfaces": {
+        "interface": {
+            "GigabitEthernet1": {
+                "name": "GigabitEthernet1",
+                "state": {
+                    "admin-status": "UP",
+                    "counters": {
+                        "in-broadcast-pkts": 0,
+                        "in-discards": 0,
+                        "in-errors": 0,
+                        "in-multicast-pkts": 0,
+                        "in-octets": 275035,
+                        "in-unicast-pkts": 2890,
+                        "in-unknown-protos": 0,
+                        "last-clear": "2017-08-14T18:02:55.000183+00:00",
+                        "out-broadcast-pkts": 0,
+                        "out-discards": 0,
+                        "out-errors": 0,
+                        "out-multicast-pkts": 0,
+                        "out-octets": 460183,
+                        "out-unicast-pkts": 1852
+                    },
+                    "ifindex": 0,
+                    "last-change": 1502733875,
+                    "oper-status": "UP",
+                    "type": "ethernetCsmacd"
+                }
+            },
+            "GigabitEthernet2": {
+                "name": "GigabitEthernet2",
+                "state": {
+                    "admin-status": "DOWN",
+                    "counters": {
+                        "in-broadcast-pkts": 0,
+                        "in-discards": 0,
+                        "in-errors": 0,
+                        "in-multicast-pkts": 0,
+                        "in-octets": 0,
+                        "in-unicast-pkts": 0,
+                        "in-unknown-protos": 0,
+                        "last-clear": "2017-08-14T18:02:55.000082+00:00",
+                        "out-broadcast-pkts": 0,
+                        "out-discards": 0,
+                        "out-errors": 0,
+                        "out-multicast-pkts": 0,
+                        "out-octets": 258,
+                        "out-unicast-pkts": 3
+                    },
+                    "ifindex": 0,
+                    "last-change": 1502733865,
+                    "oper-status": "DOWN",
+                    "type": "ethernetCsmacd"
+                }
+            }
+        }
+    }
+}

--- a/test/integration/test_profiles/iosxe/openconfig-interfaces/state/default/mocked/cli.1.data_openconfig_interfaces_interfaces.0
+++ b/test/integration/test_profiles/iosxe/openconfig-interfaces/state/default/mocked/cli.1.data_openconfig_interfaces_interfaces.0
@@ -1,0 +1,168 @@
+{
+  "openconfig-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "GigabitEthernet1",
+        "config": {
+          "type": "iana-if-type:ethernetCsmacd",
+          "name": "GigabitEthernet1",
+          "enabled": true
+        },
+        "state": {
+          "type": "iana-if-type:ethernetCsmacd",
+          "name": "GigabitEthernet1",
+          "enabled": true,
+          "ifindex": 0,
+          "admin-status": "UP",
+          "oper-status": "UP",
+          "last-change": "2017-08-14T18:04:35.000007+00:00",
+          "counters": {
+            "in-octets": 275035,
+            "in-unicast-pkts": 2890,
+            "in-broadcast-pkts": 0,
+            "in-multicast-pkts": 0,
+            "in-discards": 0,
+            "in-errors": 0,
+            "in-unknown-protos": 0,
+            "out-octets": 460183,
+            "out-unicast-pkts": 1852,
+            "out-broadcast-pkts": 0,
+            "out-multicast-pkts": 0,
+            "out-discards": 0,
+            "out-errors": 0,
+            "last-clear": "2017-08-14T18:02:55.000183+00:00"
+          }
+        },
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 0,
+              "config": {
+                "index": 0,
+                "name": "GigabitEthernet1",
+                "enabled": true
+              },
+              "state": {
+                "index": 0,
+                "name": "GigabitEthernet1.0",
+                "enabled": true,
+                "admin-status": "UP",
+                "oper-status": "UP",
+                "last-change": "2017-08-14T18:04:35.000007+00:00",
+                "counters": {
+                  "in-octets": 275035,
+                  "in-unicast-pkts": 2890,
+                  "in-broadcast-pkts": 0,
+                  "in-multicast-pkts": 0,
+                  "in-discards": 0,
+                  "in-errors": 0,
+                  "out-octets": 460183,
+                  "out-unicast-pkts": 1852,
+                  "out-broadcast-pkts": 0,
+                  "out-multicast-pkts": 0,
+                  "out-discards": 0,
+                  "out-errors": 0,
+                  "last-clear": "2017-08-14T18:02:55.000183+00:00"
+                }
+              },
+              "openconfig-if-ip:ipv6": {
+                "config": {
+                  "enabled": false
+                },
+                "state": {
+                  "enabled": false
+                }
+              }
+            }
+          ]
+        },
+        "openconfig-if-ethernet:ethernet": {
+          "config": {
+            "auto-negotiate": true
+          }
+        }
+      },
+      {
+        "name": "GigabitEthernet2",
+        "config": {
+          "type": "iana-if-type:ethernetCsmacd",
+          "name": "GigabitEthernet2",
+          "enabled": false
+        },
+        "state": {
+          "type": "iana-if-type:ethernetCsmacd",
+          "name": "GigabitEthernet2",
+          "enabled": false,
+          "ifindex": 0,
+          "admin-status": "DOWN",
+          "oper-status": "DOWN",
+          "last-change": "2017-08-14T18:04:25.000356+00:00",
+          "counters": {
+            "in-octets": 0,
+            "in-unicast-pkts": 0,
+            "in-broadcast-pkts": 0,
+            "in-multicast-pkts": 0,
+            "in-discards": 0,
+            "in-errors": 0,
+            "in-unknown-protos": 0,
+            "out-octets": 258,
+            "out-unicast-pkts": 3,
+            "out-broadcast-pkts": 0,
+            "out-multicast-pkts": 0,
+            "out-discards": 0,
+            "out-errors": 0,
+            "last-clear": "2017-08-14T18:02:55.000082+00:00"
+          }
+        },
+        "subinterfaces": {
+          "subinterface": [
+            {
+              "index": 0,
+              "config": {
+                "index": 0,
+                "name": "GigabitEthernet2",
+                "enabled": false
+              },
+              "state": {
+                "index": 0,
+                "name": "GigabitEthernet2.0",
+                "enabled": false,
+                "admin-status": "DOWN",
+                "oper-status": "DOWN",
+                "last-change": "2017-08-14T18:04:25.000356+00:00",
+                "counters": {
+                  "in-octets": 0,
+                  "in-unicast-pkts": 0,
+                  "in-broadcast-pkts": 0,
+                  "in-multicast-pkts": 0,
+                  "in-discards": 0,
+                  "in-errors": 0,
+                  "out-octets": 258,
+                  "out-unicast-pkts": 3,
+                  "out-broadcast-pkts": 0,
+                  "out-multicast-pkts": 0,
+                  "out-discards": 0,
+                  "out-errors": 0,
+                  "last-clear": "2017-08-14T18:02:55.000082+00:00"
+                }
+              },
+              "openconfig-if-ip:ipv6": {
+                "config": {
+                  "enabled": false
+                },
+                "state": {
+                  "enabled": false
+                }
+              }
+            }
+          ]
+        },
+        "openconfig-if-ethernet:ethernet": {
+          "config": {
+            "auto-negotiate": true
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/integration/test_profiles/iosxe/openconfig-network-instance/config/default/expected.json
+++ b/test/integration/test_profiles/iosxe/openconfig-network-instance/config/default/expected.json
@@ -1,0 +1,13 @@
+{
+    "network_instances": {
+        "network-instance": {
+            "default": {
+                "config": {
+                    "description": "default-vrf [read-only]",
+                    "name": "default",
+                    "type": "DEFAULT_INSTANCE"
+                },                                                                                                                                                                                                          "name": "default"
+            }
+        }
+    }
+}

--- a/test/integration/test_profiles/iosxe/openconfig-network-instance/config/default/mocked/cli.1.data_openconfig_network_instance_network_instances.0
+++ b/test/integration/test_profiles/iosxe/openconfig-network-instance/config/default/mocked/cli.1.data_openconfig_network_instance_network_instances.0
@@ -1,0 +1,59 @@
+{
+  "openconfig-network-instance:network-instances": {
+    "network-instance": [
+      {
+        "name": "default",
+        "config": {
+          "name": "default",
+          "type": "openconfig-network-instance-types:DEFAULT_INSTANCE",
+          "description": "default-vrf [read-only]"
+        },
+        "state": {
+          "name": "default",
+          "type": "openconfig-network-instance-types:DEFAULT_INSTANCE",
+          "description": "default-vrf [read-only]"
+        },
+        "tables": {
+          "table": [
+            {
+              "protocol": "openconfig-policy-types:STATIC",
+              "address-family": "openconfig-types:IPV4",
+              "config": {
+                "protocol": "openconfig-policy-types:STATIC",
+                "address-family": "openconfig-types:IPV4"
+              },
+              "state": {
+                "protocol": "openconfig-policy-types:STATIC",
+                "address-family": "openconfig-types:IPV4"
+              }
+            },
+            {
+              "protocol": "openconfig-policy-types:STATIC",
+              "address-family": "openconfig-types:IPV6",
+              "config": {
+                "protocol": "openconfig-policy-types:STATIC",
+                "address-family": "openconfig-types:IPV6"
+              },
+              "state": {
+                "protocol": "openconfig-policy-types:STATIC",
+                "address-family": "openconfig-types:IPV6"
+              }
+            }
+          ]
+        },
+        "protocols": {
+          "protocol": [
+            {
+              "identifier": "openconfig-policy-types:STATIC",
+              "name": "static",
+              "config": {
+                "identifier": "openconfig-policy-types:STATIC",
+                "name": "static"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/unit/test_jinja_filters.py
+++ b/test/unit/test_jinja_filters.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     HAS_NETADDR = False
 
-from napalm_yang.jinja_filters import ip_filters, load_filters, vlan_filters
+from napalm_yang.jinja_filters import ip_filters, load_filters, vlan_filters, timestamp_filters
 
 
 class TestJinjaFilters(unittest.TestCase):
@@ -141,3 +141,27 @@ class TestJinjaFilters(unittest.TestCase):
                          "1,2,4-10")
         self.assertEqual(vlan_filters.oc_to_vlan_range([1,  '2', '4..10', '100..200']),
                          "1,2,4-10,100-200")
+
+    def test_iso8601_to_unix(self):
+        """
+        Tests Jinja2 filter ```iso8601_to_unix```:
+
+            * check if load_filters returns the correct function
+            * check if returns empty string on None
+            * check if unix timestamp is returned as expected
+        """
+
+        self.assertEqual(load_filters()['iso8601_to_unix'], timestamp_filters.iso8601_to_unix)
+
+        self.assertEqual(timestamp_filters.iso8601_to_unix(None), '')
+
+        unix = 1500000000
+        cases = [
+            '2017-07-14T02:40:00Z',
+            '2017-07-14T02:40:00+00:00',
+            '2017-07-14T02:40:00.000000+00:00',
+            '2017-07-13T22:40:00-04:00',
+            '2017-07-13T22:40:00.000000-04:00'
+        ]
+        for case in cases:
+            self.assertEqual(timestamp_filters.iso8601_to_unix(case), unix)

--- a/test/unit/test_parser/006_iosxe_interfaces/mocked.txt
+++ b/test/unit/test_parser/006_iosxe_interfaces/mocked.txt
@@ -8,12 +8,6 @@
             "dhcp": {
             }
           }
-        },
-        "mop": {
-          "enabled": false
-        },
-        "Cisco-IOS-XE-ethernet:negotiation": {
-          "auto": true
         }
       },
       {
@@ -49,6 +43,21 @@
               "mask": "255.255.255.0"
             }
           }
+        }
+      },
+      {
+        "name": "3",
+        "shutdown": [null],
+        "ip": {
+          "no-address": {
+            "address": false
+          }
+        },
+        "mop": {
+          "enabled": false
+        },
+        "Cisco-IOS-XE-ethernet:negotiation": {
+          "auto": true
         }
       }
       ],


### PR DESCRIPTION
WIP

Initial work at a mapping for IOS-XE using Cisco's OpenConfig model support over RESTCONF. 

Also adds a timestamp filter (and test) to support Cisco's deviation to how they represent timestamps. 

This PR specifically aims to implement the oc-interface module for both config and state models. 
