### PR TITLE
Missing mapping handling

### DIFF
--- a/napalm_yang/parsers/jsonp.py
+++ b/napalm_yang/parsers/jsonp.py
@@ -106,7 +106,7 @@ class JSONParser(BaseParser):
                 match = re.search(mapping['regexp'], d)
                 d = match.group('value') if match else None
 
-        if d and "map" in mapping:
+        if d and "map" in mapping and d.lower() in mapping['map']:
             d = mapping['map'][d.lower()]
 
         if check_presence:


### PR DESCRIPTION
Scenario: an interface type is not covered by the rule's map:

```
interface TenGigabitEthernet0/0/0
 description To heaven
 ip address 192.0.2.1 255.255.255.0
```

```
    type:
	_process:
	    - value: "{{ interface_key }}"
	      regexp: "(?P<value>(\\w|-)*)\\d+"
	      map:
		  fastethernet: ethernetCsmacd
		  gigabitethernet: ethernetCsmacd
		  management: ethernetCsmacd
		  loopback: softwareLoopback
		  port-channel: ieee8023adLag
		  vlan: l3ipvlan
```

Before this:

```
...
  File "/home/pierky/napalm-yang/napalm_yang/parsers/base.py", line 151, in parse_leaf
    result = self._parse_leaf_default(attribute, m, data)
  File "/home/pierky/napalm-yang/napalm_yang/parsers/text_tree.py", line 113, in _parse_leaf_default
    return super()._parse_leaf_default(attribute, mapping, data)
  File "/home/pierky/napalm-yang/napalm_yang/parsers/jsonp.py", line 110, in _parse_leaf_default
    d = mapping['map'][d.lower()]
KeyError: u'tengigabitethernet'
```

After this:

**napalm-yang - ERROR - Wrong value for type: TenGigabitEthernet**

```
  File "/home/pierky/napalm-yang/napalm_yang/parser.py", line 95, in _parse
    self._parse_leaf(attribute, model, mapping)
  File "/home/pierky/napalm-yang/napalm_yang/parser.py", line 188, in _parse_leaf
    setter(value)
  File "/home/pierky/napalm-yang/napalm_yang/models/openconfig/interfaces/interface/config/__init__.py", line 131, in _set_type
    n:ietf:params:xml:ns:yang:iana-if-type', '@module': u'iana-if-type'}, u'fibreChannel': {'@namespace': u'urn:ietf:params:xml:ns:yang:iana-if-type', '@module': u'iana-if-type'}, u'ift:dvbRcsTdma': {'@namespace': u'urn:ietf:params:xml:ns:yang:iana-if-type', '@module': u'iana-if-type'}, u'ianaift:transpHdlc': {'@na
...
ValueError: {'error-string': 'type must be of a type compatible with identityref', 'generated-type': 'YANGDynClass(base=RestrictedClassType(base_type=unicode, restriction_type="dict_key", restriction_arg={u\'ift:mpegTransport\': {\'@namespace\': u\'urn:ietf:params:xml:ns:yang:iana-if-type\', \'@module\': u\'iana-if-type\'}, u\'ift:qam\': {\'@namespace\': u\'urn:ietf:params:xml:ns:yang:iana-if-type\', \'@module\': u\'iana-if-type\'}, u\'ift:q2931\': {\'@namespace\': u\'
...
```