### PR TITLE
Correctly append list of command results

### DIFF
--- a/napalm_yang/parser.py
+++ b/napalm_yang/parser.py
@@ -70,8 +70,10 @@ class Parser(object):
             if isinstance(r, dict) and all([isinstance(x, (str, unicode)) for x in r.values()]):
                 # Some vendors like junos return commands enclosed by a key
                 r = "\n".join(r.values())
-
-            result.append(r)
+            if isinstance(r, list):
+                result.extend(r)
+            else:
+                result.append(r)
 
         return result
 


### PR DESCRIPTION
In the _execute_methods function, if the results are returned as a list
they were being appended to the results list.  So there would be a list
inside the results list, which would later cause an error while trying
to decode the results.  This happens when parsing state against an
Arista device.  See
https://github.com/napalm-automation/napalm-yang/issues/103

If there is a better way to do this let me know and I'll adjust the PR.