### PR TITLE
adding mapping for secure-tunnel interface on srx

### DIFF
--- a/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -44,6 +44,7 @@ interfaces:
                           ae: ieee8023adLag
                           fxp: ethernetCsmacd
                           lt: tunnel
+                          st: tunnel
             enabled:
                 _process:
                     - path: "disable"


### PR DESCRIPTION
added another tunnel mapping similar to the "lt" interface in PR #95 