### PR TITLE
Update base._to_dict_leaf function to display lists

### DIFF
--- a/napalm_yang/base.py
+++ b/napalm_yang/base.py
@@ -378,6 +378,9 @@ def _to_dict_leaf(element, filter):
         try:
             value = ast.literal_eval(element.__repr__())
         except Exception:
-            value = element.__repr__()
+            if hasattr(element, '_list'):
+                value = element._list
+            else:
+                value = element.__repr__()
 
     return value


### PR DESCRIPTION
In cases where the final leaf element is a list the to dict function was
not properly translating the lists.

The trunk vlans in the interface model and the ip addresses under the
systems host entries are two examples.

This change will set the value to the `_list` element if it is present
otherwise continue on with current behavior

This PR is in response to
https://github.com/napalm-automation/napalm-yang/issues/129