### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ templates:
 
 .PHONY: tests
 tests:
-	py.test
+	pytest
 
 .PHONY: test_black
 test_black:

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     -rrequirements-dev.txt
 
 commands=
-   py.test {posargs}
+   pytest {posargs}
 
 [testenv:black]
 deps = black==18.4a4


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot