### PR TITLE
add missing 'em' interface type

### DIFF
--- a/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -36,6 +36,7 @@ interfaces:
                       map:
                           ge: ethernetCsmacd
                           xe: ethernetCsmacd
+                          em: ethernetCsmacd
                           et: ethernetCsmacd
                           irb: ethernetCsmacd
                           me: ethernetCsmacd


### PR DESCRIPTION
My qfx has an em interface:
```
root@qfx10k# show interfaces em0 
description management;
unit 0 {
    family inet {
        address 192.168.1.68/24;
    }
}
```

Without em in interfaces.yaml, parse_config fails:
```
Traceback (most recent call last):
  File "./test.py", line 16, in <module>
    running_config.parse_config(native=[config], profile=["junos"])
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/base.py", line 247, in parse_config
    parser.parse()
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 111, in parse
    self._parse(self._yang_name, self.model, self.mapping[self._yang_name])
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 117, in _parse
    self._parse_container(attribute, model, mapping)
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 172, in _parse_container
    self._parse(k, v, mapping[v._yang_name])
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 119, in _parse
    self._parse_list(attribute, model, mapping)
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 217, in _parse_list
    self._parse(key, obj, element_mapping)
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 117, in _parse
    self._parse_container(attribute, model, mapping)
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 172, in _parse_container
    self._parse(k, v, mapping[v._yang_name])
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 117, in _parse
    self._parse_container(attribute, model, mapping)
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 172, in _parse_container
    self._parse(k, v, mapping[v._yang_name])
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 121, in _parse
    self._parse_leaf(attribute, model, mapping)
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parser.py", line 229, in _parse_leaf
    value = self.parser.parse_leaf(attribute, mapping["_process"], self.bookmarks)
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parsers/base.py", line 162, in parse_leaf
    result = self._parse_leaf_default(attribute, m, data)
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parsers/xml.py", line 29, in _parse_leaf_default
    return super()._parse_leaf_default(attribute, mapping, data)
  File "/home/cspeidel/develop/napalm-yang/napalm_yang/parsers/jsonp.py", line 118, in _parse_leaf_default
    d = mapping["map"][d.lower()]
KeyError: u'em'
```
This commit fixes the KeyError for em interfaces.