### PR TITLE
Remove routing-instances from Junos "network-instance" model

### DIFF
--- a/napalm_yang/mappings/junos/parsers/config/openconfig-network-instance/network-instances.yaml
+++ b/napalm_yang/mappings/junos/parsers/config/openconfig-network-instance/network-instances.yaml
@@ -12,10 +12,8 @@ network-instances:
           from: root_network-instances.0
     network-instance:
         _process:
-            - path: "configuration"
-              key: "{{ 'global' }}"
-              from: root_network-instances.0
-            - path: "instance"
+            - key: "{{ 'global' }}"
+            - path: "routing-instances.instance"
               key: name
         afts: !include includes/afts.yaml
         config:

--- a/napalm_yang/mappings/junos/parsers/config/openconfig-network-instance/network-instances.yaml
+++ b/napalm_yang/mappings/junos/parsers/config/openconfig-network-instance/network-instances.yaml
@@ -8,7 +8,7 @@ metadata:
 
 network-instances:
     _process:
-        - path: "configuration.routing-instances"
+        - path: "configuration"
           from: root_network-instances.0
     network-instance:
         _process:


### PR DESCRIPTION
As there is no routing instance in Junos, parse_config is not returning any data when using the ``network_instance`` model.