### PR TITLE
add domain name to ios translator

### DIFF
--- a/napalm_yang/mappings/ios/translators/openconfig-system/system.yaml
+++ b/napalm_yang/mappings/ios/translators/openconfig-system/system.yaml
@@ -156,9 +156,11 @@ system:
         state:
             _process: not_implemented
     config:
-        _process: not_implemented
+        _process: unnecessary
         domain-name:
-            _process: not_implemented
+            _process:
+                - value: "ip domain-name {{ model }}\n"
+                  negate: "no ip domain-name\n"
         hostname:
             _process: not_implemented
         login-banner:

--- a/test/integration/test_profiles/ios/openconfig-system/config/default/candidate.json
+++ b/test/integration/test_profiles/ios/openconfig-system/config/default/candidate.json
@@ -29,6 +29,9 @@
                 }
             }
         },
+        "config": {
+          "domain_name": "acme.com"
+        },
         "logging": {
             "remote-servers": {
                 "remote-server": {

--- a/test/integration/test_profiles/ios/openconfig-system/config/default/merge.txt
+++ b/test/integration/test_profiles/ios/openconfig-system/config/default/merge.txt
@@ -1,3 +1,4 @@
+ip domain-name acme.com
 logging host 1.2.3.4 transport udp port 1514
 logging host 20.20.30.40 transport udp port 514
 logging 100.200.3.4

--- a/test/integration/test_profiles/ios/openconfig-system/config/default/replace.txt
+++ b/test/integration/test_profiles/ios/openconfig-system/config/default/replace.txt
@@ -1,3 +1,4 @@
+ip domain-name acme.com
 no logging host 1.2.3.4
 logging host 1.2.3.4 transport udp port 1514
 no logging host 20.20.30.40


### PR DESCRIPTION
Adds ip domain-name to the IOS translator, along with tests.

Tested translate_config and commit_config successfully against a 9300 running IOS-XE. 