### PR TITLE
Fix junos unique routing-options container

### DIFF
--- a/napalm_yang/mappings/junos/translators/openconfig-network-instance/includes/bgp.yaml
+++ b/napalm_yang/mappings/junos/translators/openconfig-network-instance/includes/bgp.yaml
@@ -3,7 +3,10 @@ _process:
     - gate: true
       when: "{{ protocol_key != 'bgp bgp' }}"
 global:
-    _process: unnecessary
+    _process:
+      - container: routing-options
+        reuse: true
+        in: "network_instance.{{ network_instance_key }}"
     afi-safis:
         _process: not_implemented
         afi-safi:
@@ -258,12 +261,10 @@ global:
         _process: unnecessary
         as:
             _process:
-              - element: "routing-options/autonomous-system/as-number"
-                in: "network_instance.{{ network_instance_key }}"
+              - element: "autonomous-system/as-number"
         router-id:
             _process:
-              - element: "routing-options/router-id"
-                in: "network_instance.{{ network_instance_key }}"
+              - element: "router-id"
     default-route-distance:
         _process: not_implemented
         config:

--- a/napalm_yang/mappings/junos/translators/openconfig-network-instance/includes/static_routes.yaml
+++ b/napalm_yang/mappings/junos/translators/openconfig-network-instance/includes/static_routes.yaml
@@ -4,6 +4,8 @@ _process:
       when: "{{ protocol_key != 'static static' }}"
 static:
     _process:
+      - container: "static"
+        reuse: true
       - container: "route"
         key_element: name
         key_value: "{{ static_key }}"

--- a/napalm_yang/mappings/junos/translators/openconfig-network-instance/network-instances.yaml
+++ b/napalm_yang/mappings/junos/translators/openconfig-network-instance/network-instances.yaml
@@ -269,7 +269,9 @@ network-instances:
                   - container: "protocols/{{ model.identifier }}"
                     replace: true
                     when: "{{ protocol_key != 'static static' }}"
-                  - container: "routing-options/static"
+                  - container: "routing-options"
+                    reuse: true
+                    in: "network_instance.{{ network_instance_key }}"
                     when: "{{ protocol_key == 'static static' }}"
                 bgp: !include includes/bgp.yaml
                 config:

--- a/test/integration/test_profiles/junos/openconfig-network-instance/config/default/merge.txt
+++ b/test/integration/test_profiles/junos/openconfig-network-instance/config/default/merge.txt
@@ -106,11 +106,7 @@
     <autonomous-system>
       <as-number>65000</as-number>
     </autonomous-system>
-  </routing-options>
-  <routing-options>
     <router-id>1.1.1.1</router-id>
-  </routing-options>
-  <routing-options>
     <static>
       <route>
         <name>10.0.0.0/24</name>

--- a/test/integration/test_profiles/junos/openconfig-network-instance/config/default/replace.txt
+++ b/test/integration/test_profiles/junos/openconfig-network-instance/config/default/replace.txt
@@ -100,11 +100,7 @@
     <autonomous-system>
       <as-number>65000</as-number>
     </autonomous-system>
-  </routing-options>
-  <routing-options>
     <router-id>1.1.1.1</router-id>
-  </routing-options>
-  <routing-options>
     <static>
       <route>
         <name>10.0.0.0/24</name>

--- a/test/integration/test_profiles/junos/openconfig-network-instance/config/default/translation.txt
+++ b/test/integration/test_profiles/junos/openconfig-network-instance/config/default/translation.txt
@@ -92,11 +92,7 @@
     <autonomous-system>
       <as-number>65000</as-number>
     </autonomous-system>
-  </routing-options>
-  <routing-options>
     <router-id>1.1.1.1</router-id>
-  </routing-options>
-  <routing-options>
     <static>
       <route>
         <name>10.0.0.0/24</name>


### PR DESCRIPTION
In the `default` test case in the `openconfig-network-instance` you can find different `routing-options` containers for the `AS`, the `router-id` and the `static` routes, like:
```
  <routing-options>
    <autonomous-system>
      <as-number>65000</as-number>
    </autonomous-system>
  </routing-options>
  <routing-options>
    <router-id>1.1.1.1</router-id>
  </routing-options>
  <routing-options>
    <static>
      <route>
        <name>10.0.0.0/24</name>
        <qualified-next-hop>
          <name>192.168.100.100</name>
          <metric>100</metric>
        </qualified-next-hop>
        <qualified-next-hop>
          <name>192.168.100.101</name>
          <metric>200</metric>
        </qualified-next-hop>
      </route>
      <route>
        <name>10.100.0.0/24</name>
        <qualified-next-hop>
          <name>192.168.100.200</name>
        </qualified-next-hop>
      </route>
    </static>
  </routing-options>
```
However there should be a unique `routing-options` container, like:
```
  <routing-options>
    <autonomous-system>
      <as-number>65000</as-number>
    </autonomous-system>
    <router-id>1.1.1.1</router-id>
    <static>
      <route>
        <name>10.0.0.0/24</name>
        <qualified-next-hop>
          <name>192.168.100.100</name>
          <metric>100</metric>
        </qualified-next-hop>
        <qualified-next-hop>
          <name>192.168.100.101</name>
          <metric>200</metric>
        </qualified-next-hop>
      </route>
      <route>
        <name>10.100.0.0/24</name>
        <qualified-next-hop>
          <name>192.168.100.200</name>
        </qualified-next-hop>
      </route>
    </static>
  </routing-options>
```
This PR should fix this...
