### PR TITLE
fix junos state unspecified interface

### DIFF
--- a/napalm_yang/mappings/junos/parsers/state/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/junos/parsers/state/openconfig-interfaces/interfaces.yaml
@@ -80,6 +80,7 @@ interfaces:
                           pimd: null
                           pime: null
                           pppoe: null
+                          unspecified: null
             counters:
                 _process: unnecessary
                 in-broadcast-pkts:


### PR DESCRIPTION
Fix for the following error while checking interface state

```
Traceback (most recent call last):
  File "client_state.py", line 54, in <module>
    candidate.parse_state(device=d)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/base.py", line 285, in parse_state
    parser.parse()
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 111, in parse
    self._parse(self._yang_name, self.model, self.mapping[self._yang_name])
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 117, in _parse
    self._parse_container(attribute, model, mapping)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 172, in _parse_container
    self._parse(k, v, mapping[v._yang_name])
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 119, in _parse
    self._parse_list(attribute, model, mapping)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 217, in _parse_list
    self._parse(key, obj, element_mapping)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 117, in _parse
    self._parse_container(attribute, model, mapping)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 172, in _parse_container
    self._parse(k, v, mapping[v._yang_name])
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 117, in _parse
    self._parse_container(attribute, model, mapping)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 172, in _parse_container
    self._parse(k, v, mapping[v._yang_name])
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 121, in _parse
    self._parse_leaf(attribute, model, mapping)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parser.py", line 229, in _parse_leaf
    value = self.parser.parse_leaf(attribute, mapping["_process"], self.bookmarks)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parsers/base.py", line 162, in parse_leaf
    result = self._parse_leaf_default(attribute, m, data)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parsers/xml.py", line 29, in _parse_leaf_default
    return super()._parse_leaf_default(attribute, mapping, data)
  File "/home/ckishimo/devel/mpls/napalm-yang/napalm_yang/parsers/jsonp.py", line 118, in _parse_leaf_default
    d = mapping["map"][d.lower()]
KeyError: u'unspecified'
```

```
ckishimo@router> show interfaces extensive | display xml | match if-type 
            <if-type>Unspecified</if-type>
            <if-type>Unspecified</if-type>
            <if-type>Unspecified</if-type>
            <if-type>Unspecified</if-type>
            <if-type>Unspecified</if-type>
            <if-type>Unspecified</if-type>
            <if-type>Loopback</if-type>
            <if-type>Ethernet</if-type>
            <if-type>Software-Pseudo</if-type>
            <if-type>Software-Pseudo</if-type>
            <if-type>Ethernet</if-type>
```