### PR TITLE
Add support for IPv6 on Juniper devices

### DIFF
--- a/napalm_yang/mappings/junos/parsers/config/openconfig-if-ip/ipv6.yaml
+++ b/napalm_yang/mappings/junos/parsers/config/openconfig-if-ip/ipv6.yaml
@@ -1,0 +1,82 @@
+---
+metadata:
+    processor: XMLParser
+
+ipv6:
+    _process: unnecessary
+    config:
+        _process: unnecessary
+        dup-addr-detect-transmits:
+            _process: not_implemented
+        enabled:
+            _process:
+                - path: "family.inet6"
+                  present: yes
+        mtu:
+            _process: not_implemented
+    addresses:
+        _process:
+            - path: "family.inet6"
+        address:
+            _process:
+                - path: "address"
+                  key: name
+                  regexp: "(?P<value>(?P<ip>.*))\\/(?P<prefix>\\d+)"
+            ip:
+                _process: unnecessary
+            config:
+                _process: unnecessary
+                ip:
+                    _process:
+                        - pre: "{{ extra_vars.address.ip }}"
+                prefix-length:
+                    _process:
+                         - pre: "{{ extra_vars.address.prefix }}"
+            vrrp:
+                _process: not_implemented
+                vrrp-group:
+                    _process: not_implemented
+                    virtual-router-id:
+                        _process: not_implemented
+                    config:
+                        _process: not_implemented
+                        virtual-address:
+                            _process: not_implemented
+                        priority:
+                            _process: not_implemented
+                        preempt:
+                            _process: not_implemented
+                        advertisement-interval:
+                            _process: not_implemented
+                        virtual-router-id:
+                            _process: not_implemented
+                        preempt-delay:
+                            _process: not_implemented
+                        accept-mode:
+                            _process: not_implemented
+    unnumbered:
+        _process: not_implemented
+        config:
+            _process: not_implemented
+            enabled:
+                _process: not_implemented
+        interface-ref:
+            _process: not_implemented
+            config:
+                _process: not_implemented
+                interface:
+                    _process: not_implemented
+                subinterface:
+                    _process: not_implemented
+    neighbors:
+        _process: not_implemented
+        neighbor:
+            _process: not_implemented
+            ip:
+                _process: not_implemented
+            config:
+                _process: not_implemented
+                ip:
+                    _process: not_implemented
+                link-layer-address:
+                    _process: not_implemented

--- a/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
+++ b/napalm_yang/mappings/junos/parsers/config/openconfig-interfaces/interfaces.yaml
@@ -44,6 +44,7 @@ interfaces:
                           lo: softwareLoopback
                           ae: ieee8023adLag
                           fxp: ethernetCsmacd
+                          em: ethernetCsmacd
                           lt: tunnel
                           st: tunnel
                           gr: tunnel

--- a/test/integration/test_profiles/junos/openconfig-interfaces/config/default/candidate.json
+++ b/test/integration/test_profiles/junos/openconfig-interfaces/config/default/candidate.json
@@ -13,6 +13,11 @@
                         "config": {
                             "enabled": false
                         }
+                    },
+                   "ipv6": {
+                        "config": {
+                            "enabled": false
+                        }
                     }
                 },
                 "subinterfaces": {
@@ -24,6 +29,11 @@
                             },
                             "index": "0",
                             "ipv4": {
+                                "config": {
+                                    "enabled": false
+                                }
+                            },
+                           "ipv6": {
                                 "config": {
                                     "enabled": false
                                 }
@@ -41,6 +51,11 @@
                 "name": "ge-0/0/0",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -70,6 +85,11 @@
                                 "config": {
                                     "enabled": true
                                 }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
                             }
                         }
                     }
@@ -84,6 +104,11 @@
                 "name": "ge-0/0/1",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -113,6 +138,11 @@
                                 "config": {
                                     "enabled": true
                                 }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
                             }
                         }
                     }
@@ -127,6 +157,11 @@
                 "name": "ge-0/0/2",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -156,6 +191,11 @@
                                 "config": {
                                     "enabled": true
                                 }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
                             }
                         }
                     }
@@ -170,6 +210,11 @@
                 "name": "ge-0/0/3",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -197,6 +242,11 @@
                                 },
                                 "config": {
                                     "enabled": true
+                                }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
                                 }
                             }
                         },
@@ -229,6 +279,11 @@
                                     "enabled": true
                                 }
                             },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
+                            },
                             "vlan": {
                                 "config": {
                                     "vlan-id": 6
@@ -247,6 +302,11 @@
                 "name": "lo0",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -275,6 +335,11 @@
                                 "config": {
                                     "enabled": true
                                 }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
                             }
                         },
                         "4225": {
@@ -297,6 +362,11 @@
                                 },
                                 "config": {
                                     "enabled": true
+                                }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
                                 }
                             }
                         }

--- a/test/integration/test_profiles/junos/openconfig-interfaces/config/default/expected.json
+++ b/test/integration/test_profiles/junos/openconfig-interfaces/config/default/expected.json
@@ -13,6 +13,11 @@
                         "config": {
                             "enabled": false
                         }
+                    },
+                   "ipv6": {
+                        "config": {
+                            "enabled": false
+                        }
                     }
                 },
                 "subinterfaces": {
@@ -38,6 +43,11 @@
                                 "config": {
                                     "enabled": true
                                 }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
                             }
                         }
                     }
@@ -52,6 +62,11 @@
                 "name": "ge-0/0/0",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -81,6 +96,11 @@
                                 "config": {
                                     "enabled": true
                                 }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
                             }
                         }
                     }
@@ -95,6 +115,11 @@
                 "name": "ge-0/0/1",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -124,6 +149,11 @@
                                 "config": {
                                     "enabled": true
                                 }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
                             }
                         }
                     }
@@ -138,6 +168,11 @@
                 "name": "ge-0/0/2",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -167,6 +202,11 @@
                                 "config": {
                                     "enabled": true
                                 }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
                             }
                         }
                     }
@@ -181,6 +221,11 @@
                 "name": "ge-0/0/3",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -208,6 +253,11 @@
                                 },
                                 "config": {
                                     "enabled": true
+                                }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
                                 }
                             }
                         },
@@ -240,6 +290,11 @@
                                     "enabled": true
                                 }
                             },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
+                            },
                             "vlan": {
                                 "config": {
                                     "vlan-id": 6
@@ -258,6 +313,11 @@
                 "name": "lo0",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -286,6 +346,11 @@
                                 "config": {
                                     "enabled": true
                                 }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
                             }
                         },
                         "4225": {
@@ -308,6 +373,11 @@
                                 },
                                 "config": {
                                     "enabled": true
+                                }
+                            },
+                           "ipv6": {
+                                "config": {
+                                    "enabled": false
                                 }
                             }
                         }

--- a/test/integration/tutorial_data/test_populating_from_file/junos/expected.json
+++ b/test/integration/tutorial_data/test_populating_from_file/junos/expected.json
@@ -12,6 +12,11 @@
                                     "enabled": true
                                 }
                             },
+                            "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
+                            },
                             "config": {
                                 "enabled": true,
                                 "name": "0",
@@ -22,6 +27,11 @@
                 },
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -39,6 +49,11 @@
                 "name": "ge-0/0/1",
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -85,6 +100,11 @@
                                     }
                                 }
                             },
+                            "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
+                            },
                             "config": {
                                 "enabled": true,
                                 "name": "0",
@@ -112,6 +132,11 @@
                                             }
                                         }
                                     }
+                                }
+                            },
+                            "ipv6": {
+                                "config": {
+                                    "enabled": false
                                 }
                             },
                             "config": {
@@ -143,6 +168,11 @@
                                     }
                                 }
                             },
+                            "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
+                            },
                             "config": {
                                 "enabled": true,
                                 "name": "2",
@@ -153,6 +183,11 @@
                 },
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }
@@ -175,6 +210,11 @@
                                     "enabled": false
                                 }
                             },
+                            "ipv6": {
+                                "config": {
+                                    "enabled": false
+                                }
+                            },
                             "config": {
                                 "enabled": true,
                                 "name": "0",
@@ -185,6 +225,11 @@
                 },
                 "routed-vlan": {
                     "ipv4": {
+                        "config": {
+                            "enabled": false
+                        }
+                    },
+                   "ipv6": {
                         "config": {
                             "enabled": false
                         }


### PR DESCRIPTION
I needed to get YANG support for IPv6 addresses to work on Juniper devices, so I simply copied the existing `ipv4.yaml` and altered it as needed.

This involved adding this section under the main `config` stanza:
```
        dup-addr-detect-transmits:
            _process: not_implemented
```

Also, I discovered that the interface name `em` was not included in the `openconfig-interfaces/interfaces.yaml` file so I added that too.